### PR TITLE
Fix build on macOS

### DIFF
--- a/ir_gdb.c
+++ b/ir_gdb.c
@@ -7,6 +7,7 @@
  * Based on Mike Pall's implementation of GDB interface for LuaJIT.
  */
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/ir_private.h
+++ b/ir_private.h
@@ -8,7 +8,7 @@
 #ifndef IR_PRIVATE_H
 #define IR_PRIVATE_H
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #ifdef IR_DEBUG
 # include <assert.h>


### PR DESCRIPTION
Corresponding compilation errors:

ir_private.h:11:10: fatal error: 'malloc.h' file not found

ir_gdb.c:162:17: error: implicit declaration of function 'offsetof' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        .shofs       = offsetof(ir_gdbjit_obj, sect),