### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,88 @@
+name: Push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**"
+permissions:
+  contents: read
+jobs:
+  x86_64:
+    name: x86_64
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: apt
+        run: |
+          apt update -y
+          DEBIAN_FRONTEND=noninteractive apt install -y \
+            gcc \
+            libcapstone-dev \
+            libcapstone4 \
+            make \
+            php-cli
+      - name: make
+        run: make TARGET=x86_64 all
+      - name: test
+        run: make TARGET=x86_64 test-ci
+  x86:
+    name: x86
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: apt
+        run: |
+          dpkg --add-architecture i386
+          apt update -y
+          DEBIAN_FRONTEND=noninteractive apt install -y \
+            gcc \
+            gcc-multilib \
+            libc6:i386 \
+            make \
+            php-cli \
+            wget
+      - name: Build capstone
+        run: |
+          # capstone isn't distributed for 32-bit so we need to build it manually
+          wget https://github.com/capstone-engine/capstone/archive/4.0.2.tar.gz -O capstone.tar.gz
+          tar zxvf capstone.tar.gz
+          cd capstone-4.0.2
+          ./make.sh nix32
+          ./make.sh install
+          cd ..
+          rm -rf capstone-4.0.2 capstone.tar.gz
+      - name: make
+        run: make TARGET=x86 all
+      - name: test
+        run: make TARGET=x86 test-ci
+  aarch64:
+    name: aarch64
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
+        name: QEMU
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt update -y
+            DEBIAN_FRONTEND=noninteractive apt install -y \
+              gcc \
+              libc6 \
+              libcapstone-dev \
+              libcapstone4 \
+              make \
+              php-cli
+          run: |
+            make CC=gcc TARGET=aarch64 all
+            # FIXME: For some reason some of the object files are rebuilt
+            make CC=gcc TARGET=aarch64 test-ci

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ $(BUILD_DIR)/ir: $(BUILD_DIR)/ir_main.o $(BUILD_DIR)/ir.o $(BUILD_DIR)/ir_strtab
 	$(BUILD_DIR)/ir_sccp.o $(BUILD_DIR)/ir_gcm.o $(BUILD_DIR)/ir_ra.o $(BUILD_DIR)/ir_emit.o \
 	$(BUILD_DIR)/ir_load.o $(BUILD_DIR)/ir_save.o $(BUILD_DIR)/ir_emit_c.o $(BUILD_DIR)/ir_dump.o \
 	$(BUILD_DIR)/ir_disasm.o $(BUILD_DIR)/ir_gdb.o $(BUILD_DIR)/ir_perf.o $(BUILD_DIR)/ir_check.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ -lcapstone $^
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lcapstone
 
 $(BUILD_DIR)/ir_test: $(BUILD_DIR)/ir_test.o $(BUILD_DIR)/ir.o $(BUILD_DIR)/ir_strtab.o $(BUILD_DIR)/ir_cfg.o \
 	$(BUILD_DIR)/ir_sccp.o $(BUILD_DIR)/ir_gcm.o $(BUILD_DIR)/ir_ra.o $(BUILD_DIR)/ir_emit.o \
 	$(BUILD_DIR)/ir_save.o $(BUILD_DIR)/ir_dump.o $(BUILD_DIR)/ir_disasm.o $(BUILD_DIR)/ir_gdb.o \
 	$(BUILD_DIR)/ir_perf.o $(BUILD_DIR)/ir_check.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ -lcapstone $^
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lcapstone
 
 $(BUILD_DIR)/ir.o: $(SRC_DIR)/ir.c $(SRC_DIR)/ir.h $(SRC_DIR)/ir_private.h $(SRC_DIR)/ir_fold.h \
 	$(BUILD_DIR)/ir_fold_hash.h
@@ -107,6 +107,9 @@ test: $(BUILD_DIR)/ir
 	$(BUILD_DIR)/ir $(SRC_DIR)/test.ir --dot $(BUILD_DIR)/ir.dot
 	dot -Tpdf $(BUILD_DIR)/ir.dot -o $(BUILD_DIR)/ir.pdf
 	BUILD_DIR=$(BUILD_DIR) SRC_DIR=$(SRC_DIR) $(PHP) $(SRC_DIR)/ir-test.php
+
+test-ci: $(BUILD_DIR)/ir
+	BUILD_DIR=$(BUILD_DIR) SRC_DIR=$(SRC_DIR) $(PHP) $(SRC_DIR)/ir-test.php --show-diff
 
 clean:
 	rm -rf $(BUILD_DIR)/ir $(BUILD_DIR)/ir_test $(BUILD_DIR)/*.o \

--- a/ir-test.php
+++ b/ir-test.php
@@ -141,6 +141,11 @@ function run_tests() {
 			} else {
 				echo "\r\e[1;31mFAIL\e[0m: $name [$test]\n";
 				$failed[$test] = $name;
+				global $show_diff;
+				if ($show_diff) {
+					$base   = substr($test, 0, -4);
+					echo file_get_contents("$base.diff");
+				}
 			}
 		} else {
 			echo "\r\e[1;31mBROK\e[0m: $name [$test]\n";
@@ -169,6 +174,9 @@ function run_tests() {
 		}
 	}
 	echo "-------------------------------\n";
+
+	return count($failed) > 0 ? 1 : 0;
 }
 
-run_tests();
+$show_diff = in_array('--show-diff', $argv, true);
+exit(run_tests());


### PR DESCRIPTION
* x86_64 uses Docker just so that the build is more easily reproducible locally
* x86_32 uses Docker to avoid dependency issues
* aarch64 uses QEMU, which unfortunately is also fairly slow
    * We do use `install`, which will create a Docker image so that dependencies don't have to be installed as part of the build

I also got a weird linker error when linking with `gcc` that doesn't happen with `clang`:

```log
 gcc -Wall -Wextra -Wno-unused-parameter -O0 -g -DIR_DEBUG=1 -DIR_TARGET_X64 -lm -o ir -lcapstone ir_main.o ir.o ir_strtab.o ir_cfg.o ir_sccp.o ir_gcm.o ir_ra.o ir_emit.o ir_load.o ir_save.o ir_emit_c.o ir_dump.o ir_disasm.o ir_gdb.o ir_perf.o ir_check.o
/usr/bin/ld: ir_disasm.o: in function `ir_disasm_branch_target':
/home/runner/work/ir/ir/ir_disasm.c:203: undefined reference to `cs_insn_group'
/usr/bin/ld: ir_disasm.o: in function `ir_disasm':
/home/runner/work/ir/ir/ir_disasm.c:344: undefined reference to `cs_open'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:350: undefined reference to `cs_option'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:354: undefined reference to `cs_option'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:414: undefined reference to `cs_malloc'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:415: undefined reference to `cs_disasm_iter'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:453: undefined reference to `cs_disasm_iter'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:575: undefined reference to `cs_free'
/usr/bin/ld: /home/runner/work/ir/ir/ir_disasm.c:655: undefined reference to `cs_close'
collect2: error: ld returned 1 exit status
```

The symbols are absolutely there (verifiable with `nm` and proven given that `clang` works fine).

I'm not sure what the `CC = aarch64-linux-gnu-gcc --sysroot=$(HOME)/php/ARM64` is needed for. Let me know and I can adjust it accordingly for `clang`.