### PR TITLE
Fix incorrect val.i64 check

### DIFF
--- a/ir.g
+++ b/ir.g
@@ -269,7 +269,7 @@ val(ir_parser_ctx *p, uint8_t op, uint32_t n, ir_ref *ref):
 		{*ref = ir_strl(p->ctx, str, len);}
 	|	DECNUMBER(IR_I32, &val)
 		{if (kind != IR_OPND_NUM && kind != IR_OPND_PROB) yy_error("unexpected number");}
-		{if (val.i64 < 0 && val.i64 >= 0x7ffffff) yy_error("number out of range");}
+		{if (val.i64 < 0 || val.i64 > 0x7fffffff) yy_error("number out of range");}
 		{*ref = val.u64;}
 	|	"null"
 		{*ref = IR_UNUSED;}

--- a/ir_load.c
+++ b/ir_load.c
@@ -893,7 +893,7 @@ static int parse_val(int sym, ir_parser_ctx *p, uint8_t op, uint32_t n, ir_ref *
 	} else if (sym == YY_DECNUMBER) {
 		sym = parse_DECNUMBER(sym, IR_I32, &val);
 		if (kind != IR_OPND_NUM && kind != IR_OPND_PROB) yy_error("unexpected number");
-		if (val.i64 < 0 && val.i64 >= 0x7ffffff) yy_error("number out of range");
+		if (val.i64 < 0 || val.i64 > 0x7fffffff) yy_error("number out of range");
 		*ref = val.u64;
 	} else if (sym == YY_NULL) {
 		sym = get_sym();


### PR DESCRIPTION
Fixes a couple of typos in the check condition:
* `0x7ffffff` -> `0x7fffffff` (one f too little)
* `&&` means that the check is always false, should've been `||`
* `>=` -> `>` because 0x7ffffff is a valid i32.