### PR TITLE
build: MSVC compatibility

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,8 @@ on:
 permissions:
   contents: read
 jobs:
-  x86_64:
-    name: x86_64
+  Linux_x86_64:
+    name: 'Linux x86_64'
     runs-on: ubuntu-22.04
     container:
       image: ubuntu:22.04
@@ -29,8 +29,8 @@ jobs:
         run: make TARGET=x86_64 all
       - name: test
         run: make TARGET=x86_64 test-ci
-  x86:
-    name: x86
+  Linux_i386:
+    name: 'Linux i386'
     runs-on: ubuntu-22.04
     container:
       image: ubuntu:22.04
@@ -61,8 +61,8 @@ jobs:
         run: make TARGET=x86 all
       - name: test
         run: make TARGET=x86 test-ci
-  aarch64:
-    name: aarch64
+  Linux_aarch64:
+    name: 'Linux aarch64'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
             # FIXME: For some reason some of the object files are rebuilt
             make CC=gcc TARGET=aarch64 test-ci
 
-  windows:
+  Windows:
     strategy:
       matrix:
         arch: [x86, amd64]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -103,4 +103,12 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
-      - run: nmake -nologo -f win32/Makefile VCPKG_DIR=${{ matrix.vcpkg_dir }} VCPKG_TRIPLET=${{ matrix.vcpkg_triplet }}
+      - name: Build
+        shell: cmd
+        run: nmake -nologo -f win32/Makefile VCPKG_DIR=${{ matrix.vcpkg_dir }} VCPKG_TRIPLET=${{ matrix.vcpkg_triplet }}
+      - name: Test
+        shell: cmd
+        run: |
+          nmake -nologo -f win32/Makefile VCPKG_DIR=${{ matrix.vcpkg_dir }} VCPKG_TRIPLET=${{ matrix.vcpkg_triplet }} test
+          type win32\build_${{ matrix.vcpkg_triplet }}\test.log
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -86,3 +86,21 @@ jobs:
             make CC=gcc TARGET=aarch64 all
             # FIXME: For some reason some of the object files are rebuilt
             make CC=gcc TARGET=aarch64 test-ci
+
+  windows:
+    strategy:
+      matrix:
+        arch: [x86, amd64]
+        include:
+          - vcpkg_dir: .\win32\vcpkg
+          - vcpkg_triplet: x86-windows
+            arch: x86
+          - vcpkg_triplet: x64-windows
+            arch: amd64
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      - run: nmake -nologo -f win32/Makefile VCPKG_DIR=${{ matrix.vcpkg_dir }} VCPKG_TRIPLET=${{ matrix.vcpkg_triplet }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tests/**/*.exp
 tests/**/*.ir
 tests/**/*.out
 tests/**/*.log
+
+win32/vcpkg
+win32/build_*

--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -370,7 +370,7 @@ static void ir_xlat_binding(ir_ctx *ctx, ir_ref *_xlat)
 	ir_hashtab *binding = ctx->binding;
 	uint32_t hash_size = (uint32_t)(-(int32_t)binding->mask);
 
-	memset(binding->data - (hash_size * sizeof(uint32_t)), -1, hash_size * sizeof(uint32_t));
+	memset((char*)binding->data - (hash_size * sizeof(uint32_t)), -1, hash_size * sizeof(uint32_t));
 	n1 = binding->count;
 	n2 = 0;
 	pos = 0;

--- a/ir_load.c
+++ b/ir_load.c
@@ -15,7 +15,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 const unsigned char *yy_buf;
 const unsigned char *yy_end;

--- a/ir_main.c
+++ b/ir_main.c
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	f = fopen(input, "r");
+	f = fopen(input, "rb");
 	if (!f) {
 		fprintf(stderr, "ERROR: Cannot open input file '%s'\n", input);
 		return 1;
@@ -420,6 +420,7 @@ int main(int argc, char **argv)
 				int (*func)(void) = entry;
 				int ret;
 
+#ifndef _WIN32
 				ir_perf_map_register("test", entry, size);
 				ir_perf_jitdump_open();
 				ir_perf_jitdump_register("test", entry, size);
@@ -427,6 +428,7 @@ int main(int argc, char **argv)
 				ir_mem_unprotect(entry, 4096);
 				ir_gdb_register("test", entry, size, sizeof(void*), 0);
 				ir_mem_protect(entry, 4096);
+#endif
 
 				ret = func();
 				fflush(stdout);

--- a/ir_private.h
+++ b/ir_private.h
@@ -17,6 +17,16 @@
 # define IR_ASSERT(x)
 #endif
 
+#ifdef _WIN32
+# include <intrin.h>
+# ifdef _M_X64
+#  pragma intrinsic(_BitScanForward64)
+#  pragma intrinsic(_BitScanReverse64)
+# endif
+# pragma intrinsic(_BitScanForward)
+# pragma intrinsic(_BitScanReverse)
+#endif
+
 #ifdef __has_builtin
 # if __has_builtin(__builtin_expect)
 #   define EXPECTED(condition)   __builtin_expect(!!(condition), 1)
@@ -104,7 +114,7 @@ IR_ALWAYS_INLINE uint32_t ir_ntz(uint32_t num)
 #elif defined(_WIN32)
 	uint32_t index;
 
-	if (!BitScanForward(&index, num)) {
+	if (!_BitScanForward(&index, num)) {
 		/* undefined behavior */
 		return 32;
 	}
@@ -133,9 +143,9 @@ IR_ALWAYS_INLINE uint32_t ir_ntzl(uint64_t num)
 	unsigned long index;
 
 #if defined(_WIN64)
-	if (!BitScanForward64(&index, num)) {
+	if (!_BitScanForward64(&index, num)) {
 #else
-	if (!BitScanForward(&index, num)) {
+	if (!_BitScanForward(&index, num)) {
 #endif
 		/* undefined behavior */
 		return 64;
@@ -165,7 +175,7 @@ IR_ALWAYS_INLINE int ir_nlz(uint32_t num)
 #elif defined(_WIN32)
 	uint32_t index;
 
-	if (!BitScanReverse(&index, num)) {
+	if (!_BitScanReverse(&index, num)) {
 		/* undefined behavior */
 		return 32;
 	}
@@ -192,7 +202,11 @@ IR_ALWAYS_INLINE int ir_nlzl(uint64_t num)
 #elif defined(_WIN32)
 	uint32_t index;
 
-	if (!BitScanReverse64(&index, num)) {
+#if defined(_WIN64)
+	if (!_BitScanReverse64(&index, num)) {
+#else
+	if (!_BitScanReverse(&index, num)) {
+#endif
 		/* undefined behavior */
 		return 64;
 	}
@@ -223,7 +237,11 @@ IR_ALWAYS_INLINE int ir_nlzl(uint64_t num)
 # define ir_bitset_ntz  ir_ntz
 #else
 # define IR_BITSET_BITS   64
-# define IR_BITSET_ONE    1UL
+# ifdef _M_X64 /* MSVC*/
+#  define IR_BITSET_ONE    1ui64
+# else
+#  define IR_BITSET_ONE    1UL
+# endif
 # define ir_bitset_base_t uint64_t
 # define ir_bitset_ntz    ir_ntzl
 #endif

--- a/ir_ra.c
+++ b/ir_ra.c
@@ -862,7 +862,11 @@ static void ir_add_phi_move(ir_ctx *ctx, uint32_t b, ir_ref from, ir_ref to)
 	}
 }
 
+#ifndef _WIN32
 static int ir_block_cmp(const void *b1, const void *b2, void *data)
+#else
+static int ir_block_cmp(void *data, const void *b1, const void *b2)
+#endif
 {
 	ir_ctx *ctx = data;
 	int d1 = ctx->cfg_blocks[*(ir_ref*)b1].loop_depth;
@@ -1047,7 +1051,12 @@ int ir_coalesce(ir_ctx *ctx)
 		}
 	}
 
-	qsort_r(blocks.l.a.refs, ir_worklist_len(&blocks), sizeof(ir_ref), ir_block_cmp, ctx);
+#ifndef _WIN32
+# define qsort_fn qsort_r
+#else
+# define qsort_fn qsort_s
+#endif
+	qsort_fn(blocks.l.a.refs, ir_worklist_len(&blocks), sizeof(ir_ref), ir_block_cmp, ctx);
 
 	while (ir_worklist_len(&blocks)) {
 		uint32_t i;

--- a/ir_strtab.c
+++ b/ir_strtab.c
@@ -206,7 +206,7 @@ const char *ir_strtab_str(ir_strtab *strtab, ir_ref idx)
 void ir_strtab_free(ir_strtab *strtab)
 {
 	uint32_t hash_size = (uint32_t)(-(int32_t)strtab->mask);
-	char *data = strtab->data - (hash_size * sizeof(uint32_t));
+	char *data = (char*)strtab->data - (hash_size * sizeof(uint32_t));
 	ir_mem_free(data);
 	strtab->data = NULL;
 	if (strtab->buf) {

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1,0 +1,104 @@
+
+!if "$(BUILD)" == ""
+BUILD=release
+!endif
+
+!if "$(VCPKG_TRIPLET)" == ""
+VCPKG_TRIPLET=$(VSCMD_ARG_TGT_ARCH)-windows
+!endif
+
+!if "$(BUILD_DIR)" == ""
+BUILD_DIR=win32\build_$(VCPKG_TRIPLET)
+!endif
+SRC_DIR=.
+
+!if "$(VCPKG_DIR)" == ""
+VCPKG_DIR=win32\vcpkg
+!endif
+PATH=$(PATH);$(VCPKG_DIR)\installed\$(VCPKG_TRIPLET)\bin
+
+CFLAGS=/nologo /utf-8 /W3 /EHsc /Zi /I$(BUILD_DIR) /I$(VCPKG_DIR)\installed\$(VCPKG_TRIPLET)\include
+LDFLAGS=/nologo
+!if "$(BUILD)" == "release"
+CFLAGS=$(CFLAGS) /MT /Ox
+!else
+CFLAGS=$(CFLAGS) /MTd /Od /DEBUG /D_DEBUG /DIR_DEBUG=1
+LDFLAGS=$(LDFLAGS) /DEBUG
+!endif
+
+!if "$(CC)" == ""
+CC=cl.exe
+!endif
+
+!if "$(LD)" == ""
+LD=link.exe
+!endif
+
+!if "$(TARGET)" == ""
+TARGET = $(VSCMD_ARG_TGT_ARCH)
+!endif
+!if "$(TARGET)" == "x64"
+CFLAGS=$(CFLAGS) /DIR_TARGET_X64
+DASM_ARCH=x86
+DASM_FLAGS=-D X64=1
+!endif
+!if "$(TARGET)" == "x86"
+CFLAGS=$(CFLAGS) /DIR_TARGET_X86
+DASM_ARCH=x86
+DASM_FLAGS=
+!endif
+
+LDFLAGS=$(LDFLAGS) /libpath:$(VCPKG_DIR)\installed\$(VCPKG_TRIPLET)\lib
+
+LIBS=psapi.lib capstone.lib
+
+OBJS_COMMON=$(BUILD_DIR)\ir.obj $(BUILD_DIR)\ir_strtab.obj $(BUILD_DIR)\ir_cfg.obj \
+	$(BUILD_DIR)\ir_sccp.obj $(BUILD_DIR)\ir_gcm.obj $(BUILD_DIR)\ir_ra.obj $(BUILD_DIR)\ir_emit.obj \
+	$(BUILD_DIR)\ir_load.obj $(BUILD_DIR)\ir_save.obj $(BUILD_DIR)\ir_emit_c.obj $(BUILD_DIR)\ir_dump.obj \
+	$(BUILD_DIR)\ir_disasm.obj $(BUILD_DIR)\ir_check.obj
+OBJS_IR = $(BUILD_DIR)\ir_main.obj
+OBJS_IR_TEST = $(BUILD_DIR)\ir_test.obj
+
+all: $(BUILD_DIR)\ir.exe
+
+$(BUILD_DIR)\ir.exe: builddir capstone $(BUILD_DIR)\ir_emit_$(DASM_ARCH).h $(BUILD_DIR)\ir_fold_hash.h $(OBJS_IR) $(OBJS_COMMON)
+	"$(LD)" $(LDFLAGS) $(OBJS_COMMON) $(OBJS_IR) $(LIBS) /out:$@
+
+$(BUILD_DIR)\ir_fold_hash.h: $(BUILD_DIR)\gen_ir_fold_hash.exe $(SRC_DIR)\ir_fold.h $(SRC_DIR)\ir.h
+	$(BUILD_DIR)\gen_ir_fold_hash.exe < $(SRC_DIR)\ir_fold.h > $(BUILD_DIR)\ir_fold_hash.h
+$(BUILD_DIR)\gen_ir_fold_hash.exe: $(SRC_DIR)\gen_ir_fold_hash.c $(SRC_DIR)\ir_strtab.c
+	"$(CC)" $(CFLAGS) /Fo$(BUILD_DIR)\ /Fe$@ $**
+
+$(BUILD_DIR)\minilua.exe: $(SRC_DIR)\dynasm\minilua.c
+	"$(CC)" /Fo$(BUILD_DIR)\ /Fe$@ $**
+$(BUILD_DIR)\ir_emit_$(DASM_ARCH).h: $(BUILD_DIR)\minilua.exe
+	$(BUILD_DIR)\minilua.exe $(SRC_DIR)\dynasm\dynasm.lua $(DASM_FLAGS) -o $@ $(SRC_DIR)\ir_$(DASM_ARCH).dasc
+
+{$(SRC_DIR)}.c{$(BUILD_DIR)}.obj:
+	"$(CC)" $(CFLAGS) /Fo$@ /c $<
+
+# If the vcpkg dir exists, lets assume we're good with the deps.
+!if !exist($(VCPKG_DIR))
+vcpkg:
+	git clone https://github.com/Microsoft/vcpkg.git "$(VCPKG_DIR)"
+	"$(VCPKG_DIR)\bootstrap-vcpkg.bat"
+!else
+vcpkg:
+!endif
+
+capstone: vcpkg
+	"$(VCPKG_DIR)\vcpkg.exe" install --triplet=$(VCPKG_TRIPLET) capstone
+
+!if !exist($(BUILD_DIR))
+builddir:
+	md "$(BUILD_DIR)"
+!else
+builddir:
+!endif
+
+test: $(BUILD_DIR)\ir.exe
+	$(BUILD_DIR)\ir.exe $(SRC_DIR)\test.ir --dump --save $(BUILD_DIR)\test.log
+
+clean:
+	del /f /q $(BUILD_DIR)\*.obj $(BUILD_DIR)\*.exe $(BUILD_DIR)\*.pdb $(BUILD_DIR)\*.ilk $(BUILD_DIR)\*.h
+


### PR DESCRIPTION
This patch brings inital MSVC support, adding very basic fixes for code and build infra. Changes included:

- Basic code fixes to allow compiling with MSHV
- Makefile for nmake
- Extended pipeline yaml for building on Windows
- The first simple test using `ir.exe test.ir` is executed, not all the code parts are tested yet

The dependency on `libcapstone` is provided through [vcpkg](https://vcpkg.io/).

There is more to go especially to implement the full test suite and also involve the runtime execution part. There will be more build, code, test and infrastructure work required which can be build upon the base brought in this patch.


Perhaps this patch should be seen as a discussion starter. A cleaner approach could be also to separate the MSVC related code into some framework under `./win32/...` instead of polluting the codebase with `#ifdef`s (and more are to come). That way, there could be say also OS code separated like Linux/Unix/Windows specific that would share some headers and provide a platform specific code in separate C files. Maybe there can be a better approach, it just looks to me that an initial MSVC support is a good point to work out some long term strategy for a cleaner code base.

Signed-off-by: Anatol Belski <ab@php.net>
