### PR TITLE
Enhance ir test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,10 @@ test: $(BUILD_DIR)/ir $(BUILD_DIR)/ir-test
 	$(BUILD_DIR)/ir $(SRC_DIR)/test.ir --dump --save 2>$(BUILD_DIR)/test.log
 	$(BUILD_DIR)/ir $(SRC_DIR)/test.ir --dot $(BUILD_DIR)/ir.dot
 	dot -Tpdf $(BUILD_DIR)/ir.dot -o $(BUILD_DIR)/ir.pdf
-	BUILD_DIR=$(BUILD_DIR) SRC_DIR=$(SRC_DIR) $(BUILD_DIR)/ir-test
+	$(BUILD_DIR)/ir-test $(SRC_DIR)/tests
 
 test-ci: $(BUILD_DIR)/ir $(BUILD_DIR)/ir-test
-	BUILD_DIR=$(BUILD_DIR) SRC_DIR=$(SRC_DIR) $(BUILD_DIR)/ir-test --show-diff
+	$(BUILD_DIR)/ir-test --show-diff $(SRC_DIR)/tests
 
 clean:
 	rm -rf $(BUILD_DIR)/ir $(BUILD_DIR)/ir_test $(BUILD_DIR)/*.o \

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -118,15 +118,11 @@ $(BUILD_DIR)\ir-test.exe: $(SRC_DIR)/ir-test.cxx
 test: $(BUILD_DIR)\ir.exe $(BUILD_DIR)\ir-test.exe
 	set PATH=$(VCPKG_DIR)\installed\$(VCPKG_TRIPLET)\bin:%%PATH%%
 	$(BUILD_DIR)\ir.exe $(SRC_DIR)\test.ir --dump --save $(BUILD_DIR)\test.log
-	set BUILD_DIR=$(BUILD_DIR)
-	set SRC_DIR=$(SRC_DIR)
-	$(BUILD_DIR)\ir-test.exe
+	$(BUILD_DIR)\ir-test.exe $(SRC_DIR)\tests
 
 test-ci: $(BUILD_DIR)\ir.exe $(BUILD_DIR)\ir-test.exe
 	set PATH=$(VCPKG_DIR)\installed\$(VCPKG_TRIPLET)\bin:%%PATH%%
-	set BUILD_DIR=$(BUILD_DIR)
-	set SRC_DIR=$(SRC_DIR)
-	$(BUILD_DIR)\ir-test.exe --show-diff
+	$(BUILD_DIR)\ir-test.exe --show-diff $(SRC_DIR)\tests
 
 clean:
 	del /f /q $(BUILD_DIR)\*.obj $(BUILD_DIR)\*.exe $(BUILD_DIR)\*.pdb $(BUILD_DIR)\*.ilk $(BUILD_DIR)\*.h


### PR DESCRIPTION
This PR is a series enhancement to ir-test to facilitate debugging and development.
7a62d05 [ir-test]: Use g++-12 to build ir-test
8878ddb [ir-test]: Enable user to specify tests to run
201dee1 [ir-test]: add --help option and print program usage
3a2ab53 [ir-test]: Make ir-test run from any directory