### PR TITLE
[ir-test]: Fix #25: use 'fc.exe' for diff on Windows

### DIFF
--- a/ir-test.cxx
+++ b/ir-test.cxx
@@ -24,13 +24,15 @@
 # define PATH_SEP "\\"
 # define EXE_SUF ".exe"
 # define REGEX_FLAGS std::regex::extended
-# define DIFF_ARGS "--strip-trailing-cr"
+# define DIFF_CMD "fc.exe"
+# define DIFF_ARGS "/n"
 # define IR_ARGS "--no-abort-fault"
 #else
 # define PATH_SEP "/"
 # define EXE_SUF ""
 # define REGEX_FLAGS std::regex::ECMAScript | std::regex::multiline
-# define DIFF_ARGS ""
+# define DIFF_CMD "diff"
+# define DIFF_ARGS "--strip-trailing-cr -u"
 # define IR_ARGS ""
 #endif
 
@@ -182,7 +184,7 @@ namespace ir {
 			in_os.close();
 
 			auto test_cmd = ::ir_exe + " " + ir_file + " " + args + " " + IR_ARGS + " >" + out_file + " 2>&1";
-			auto diff_cmd = std::string("diff") + " " + DIFF_ARGS + " -u " + exp_file + " " + out_file + " > " + diff_file + " 2>&1";
+			auto diff_cmd = std::string(DIFF_CMD) + " " + DIFF_ARGS + " " + exp_file + " " + out_file + " > " + diff_file + " 2>&1";
 
 			int ret_code = std::system(test_cmd.c_str()) >> 0x8;
 


### PR DESCRIPTION
Fix: https://github.com/dstogov/ir/issues/25
001.irt is specially changed for test to fail.

Now on Windows
```
> nmake.exe -f .\win32\Makefile test-ci

001.irt is specially changed for test to fail.
FAIL: 001: add function [.\tests\001.irt]
Comparing files .\TESTS\001.exp and .\TESTS\001.OUT
***** .\TESTS\001.exp
    1:  {
    2:          uintptr_t c_1 = 1;
    3:          bool c_2 = 0;
***** .\TESTS\001.OUT
    1:  {
    2:          uintptr_t c_1 = 0;
    3:          bool c_2 = 0;
*****
```

On Linux
```bash
tony@Win11Z790I:~/ir$ ./ir-test --show-diff ./tests/001.irt 
FAIL: 001: add function [./tests/001.irt]    
--- ./tests/001.exp     2023-04-23 10:50:48.469742881 +0800
+++ ./tests/001.out     2023-04-23 10:50:48.469742881 +0800
@@ -1,5 +1,5 @@
 {
-       uintptr_t c_1 = 1;
+       uintptr_t c_1 = 0;
        bool c_2 = 0;
        bool c_3 = 1;
        l_1 = START(l_5);

--------------------------------
Test Summary
--------------------------------
Total: 1
Passed: 0
Expected fail: 0
Failed: 1
Skipped: 0
--------------------------------
FAILED TESTS
--------------------------------
001: add function [./tests/001.irt]
--------------------------------
```