### PR TITLE
Add ir.a target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ $(BUILD_DIR):
 $(BUILD_DIR)/ir: $(OBJS_COMMON) $(OBJS_IR)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lcapstone
 
+$(BUILD_DIR)/ir.a: $(OBJS_COMMON)
+	ar r $@ $^
+
 $(BUILD_DIR)/ir_test: $(OBJS_COMMON) $(OBJS_IR_TEST)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lcapstone
 


### PR DESCRIPTION
This makes it easier to use as a library:

```
  $ make ir.a
  ...
  $ gcc test.c ir.a -o test
  $ ./test
  :)
  $
```
