### PR TITLE
Fix build with older libstdc++

### DIFF
--- a/ir-test.cxx
+++ b/ir-test.cxx
@@ -30,7 +30,7 @@
 #else
 # define PATH_SEP "/"
 # define EXE_SUF ""
-# define REGEX_FLAGS std::regex::ECMAScript | std::regex::multiline
+# define REGEX_FLAGS std::regex::ECMAScript
 # define DIFF_CMD "diff"
 # define DIFF_ARGS "--strip-trailing-cr -u"
 # define IR_ARGS ""


### PR DESCRIPTION
The current 'test' target fails with older versions of libstdc++ found in various Linux distributions. The error appears to be related to the lack of support for regex::multiline in these older libraries.

Error messages:
```
g++ -O3 -std=c++17 ir-test.cxx -o ir-test
ir-test.cxx: In member function 'void ir::test::parse()':
ir-test.cxx:33:59: error: 'multiline' is not a member of std::__cxx11::regex
 33 | # define REGEX_FLAGS std::regex::ECMAScript | std::regex::multiline
    |                                                           ^~~~~~~~~
ir-test.cxx:126:61: note: in expansion of macro 'REGEX_FLAGS'
126 |                         std::regex sect_reg("^--[A-Z]+--$", REGEX_FLAGS);
    |                                                             ^~~~~~~~~~~
```

Tested on Ubuntu Linux 22.04-LTS.