### PR TITLE
[Fix]: ir_print_const() prints enclosing quote or not

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -67,13 +67,16 @@ const char *ir_op_name[IR_LAST_OP] = {
 #endif
 };
 
-void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f)
+void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted)
 {
 	if (insn->op == IR_FUNC) {
 		fprintf(f, "%s", ir_get_str(ctx, insn->val.i32));
 		return;
 	} else if (insn->op == IR_STR) {
-		fprintf(f, "\"%s\"", ir_get_str(ctx, insn->val.i32));
+		if (quoted)
+			fprintf(f, "\"%s\"", ir_get_str(ctx, insn->val.i32));
+		else
+			fprintf(f, "%s", ir_get_str(ctx, insn->val.i32));
 		return;
 	}
 	IR_ASSERT(IR_IS_CONST_OP(insn->op) || insn->op == IR_FUNC_ADDR);

--- a/ir.h
+++ b/ir.h
@@ -596,7 +596,7 @@ ir_ref ir_const_str(ir_ctx *ctx, ir_ref str);
 
 ir_ref ir_unique_const_addr(ir_ctx *ctx, uintptr_t c);
 
-void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f);
+void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted);
 
 ir_ref ir_str(ir_ctx *ctx, const char *s);
 ir_ref ir_strl(ir_ctx *ctx, const char *s, size_t len);

--- a/ir_dump.c
+++ b/ir_dump.c
@@ -16,7 +16,7 @@ void ir_dump(const ir_ctx *ctx, FILE *f)
 
 	for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
 		fprintf(f, "%05d %s %s(", i, ir_op_name[insn->op], ir_type_name[insn->type]);
-		ir_print_const(ctx, insn, f);
+		ir_print_const(ctx, insn, f, true);
 		fprintf(f, ")\n");
 	}
 
@@ -65,7 +65,12 @@ void ir_dump_dot(const ir_ctx *ctx, FILE *f)
 	fprintf(f, "\trankdir=TB;\n");
 	for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
 		fprintf(f, "\tc%d [label=\"C%d: CONST %s(", -i, -i, ir_type_name[insn->type]);
-		ir_print_const(ctx, insn, f);
+		/* FIXME(tony):
+  		   We still cannot handle strings with double quote inside, such as
+				"Hamlet said, \"To be, or not to be\"".
+   		   'dot' command reports syntax error.
+		*/
+		ir_print_const(ctx, insn, f, false);
 		fprintf(f, ")\",style=filled,fillcolor=yellow];\n");
 	}
 

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -18,7 +18,7 @@ static int ir_emit_dessa_move(ir_ctx *ctx, uint8_t type, ir_ref from, ir_ref to)
 		fprintf(f, "\ttmp = ");
 	}
 	if (IR_IS_CONST_REF(from)) {
-		ir_print_const(ctx, &ctx->ir_base[from], f);
+		ir_print_const(ctx, &ctx->ir_base[from], f, true);
 		fprintf(f, ";\n");
 	} else if (from) {
 		fprintf(f, "d_%d;\n", ctx->vregs[from]);
@@ -31,7 +31,7 @@ static int ir_emit_dessa_move(ir_ctx *ctx, uint8_t type, ir_ref from, ir_ref to)
 static void ir_emit_ref(ir_ctx *ctx, FILE *f, ir_ref ref)
 {
 	if (IR_IS_CONST_REF(ref)) {
-		ir_print_const(ctx, &ctx->ir_base[ref], f);
+		ir_print_const(ctx, &ctx->ir_base[ref], f, true);
 	} else {
 		ir_insn *insn = &ctx->ir_base[ref];
 		if (insn->op == IR_VLOAD) {

--- a/ir_save.c
+++ b/ir_save.c
@@ -26,13 +26,13 @@ void ir_save(const ir_ctx *ctx, FILE *f)
 			}
 		} else if (insn->op == IR_FUNC_ADDR) {
 			fprintf(f, "func_addr(");
-			ir_print_const(ctx, insn, f);
+			ir_print_const(ctx, insn, f, true);
 			if (insn->const_flags) {
 				fprintf(f, ", %d", insn->const_flags);
 			}
 			fprintf(f, ")");
 		} else {
-			ir_print_const(ctx, insn, f);
+			ir_print_const(ctx, insn, f, true);
 		}
 		fprintf(f, ";\n");
 	}

--- a/ir_sccp.c
+++ b/ir_sccp.c
@@ -775,7 +775,7 @@ int ir_sccp(ir_ctx *ctx)
 		for (i = 1; i < ctx->insns_count; i++) {
 			if (IR_IS_CONST_OP(_values[i].op)) {
 				fprintf(stderr, "%d. CONST(", i);
-				ir_print_const(ctx, &_values[i], stderr);
+				ir_print_const(ctx, &_values[i], stderr, true);
 				fprintf(stderr, ")\n");
 #if IR_COMBO_COPY_PROPAGATION
 			} else if (_values[i].op == IR_COPY) {


### PR DESCRIPTION
Current ir_print_const() will by default print out the enclosing double quote for any string, but this will lead to syntax error in dumped dot file by ir_dump_dot() reported by 'dot' command.

ir_print_const() now has the fourth parameter to indicate whether prints out the enclosing double quote(") or not.

OLD: ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f)
NEW: ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted)