### PR TITLE
ci: windows: Switch to Server 2019 runner image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86, amd64]
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
There seems to be a weird issue with VC++ toolset and host OS version, that makes x86 Windows builds of capstone misbehave. It is not quite clear, what is the exact issue, but switching to another runner image that also uses a bit older toolset seems to help.

Having a bit older host OS or toolset should be a temporary measure. Switching back to Server 2022 can be checked at some later point. 

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>