### PR TITLE
Fixup examples by making ir_init initialize the ret_type as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ OBJS_COMMON = $(BUILD_DIR)/ir.o $(BUILD_DIR)/ir_strtab.o $(BUILD_DIR)/ir_cfg.o \
 OBJS_IR = $(BUILD_DIR)/ir_main.o $(LLVM_OBJS)
 EXAMPLE_EXES = $(EXAMPLES_BUILD_DIR)/mandelbrot \
 	$(EXAMPLES_BUILD_DIR)/0001-basic \
-	$(EXAMPLES_BUILD_DIR)/0001-while \
-	$(EXAMPLES_BUILD_DIR)/0001-pointer \
-	$(EXAMPLES_BUILD_DIR)/0001-func \
+	$(EXAMPLES_BUILD_DIR)/0002-while \
+	$(EXAMPLES_BUILD_DIR)/0003-pointer \
+	$(EXAMPLES_BUILD_DIR)/0004-func \
 	$(EXAMPLES_BUILD_DIR)/0005-basic-runner-func
 
 all: $(BUILD_DIR) $(BUILD_DIR)/ir $(BUILD_DIR)/tester

--- a/examples/0001-basic.c
+++ b/examples/0001-basic.c
@@ -31,7 +31,7 @@ void gen_myfunc(ir_ctx *ctx)
 
 int main(int argc, char **argv)
 {
-	ir_ctx ctx = {0};
+	ir_ctx ctx;
 
 	ir_consistency_check();
 

--- a/examples/0002-while.c
+++ b/examples/0002-while.c
@@ -40,7 +40,7 @@ void gen_myfunc(ir_ctx *ctx)
 
 int main(int argc, char **argv)
 {
-	ir_ctx ctx = {0};
+	ir_ctx ctx;
 
 	ir_consistency_check();
 

--- a/examples/0003-pointer.c
+++ b/examples/0003-pointer.c
@@ -34,7 +34,7 @@ void gen_myfunc(ir_ctx *ctx)
 
 int main(int argc, char **argv)
 {
-	ir_ctx ctx = {0};
+	ir_ctx ctx;
 
 	ir_consistency_check();
 

--- a/examples/0004-func.c
+++ b/examples/0004-func.c
@@ -40,7 +40,7 @@ void gen_myfunc(ir_ctx *ctx)
 
 int main(int argc, char **argv)
 {
-	ir_ctx ctx = {0};
+	ir_ctx ctx;
 
 	ir_consistency_check();
 

--- a/examples/0005-basic-runner-func.c
+++ b/examples/0005-basic-runner-func.c
@@ -46,7 +46,7 @@ void run(myfunc_t func)
 
 int main(int argc, char **argv)
 {
-	ir_ctx ctx = {0};
+	ir_ctx ctx;
 
 	ir_consistency_check();
 

--- a/examples/mandelbrot.c
+++ b/examples/mandelbrot.c
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
 	ir_save(&ctx, stderr);
 	ir_dump_live_ranges(&ctx, stderr);
 	f = fopen("mandelbrot.dot", "w+");
-	ir_dump_dot(&ctx, f);
+	ir_dump_dot(&ctx, "dump", f);
 	fclose(f);
 
 	size_t size;

--- a/ir.c
+++ b/ir.c
@@ -370,6 +370,8 @@ void ir_init(ir_ctx *ctx, uint32_t flags, ir_ref consts_limit, ir_ref insns_limi
 	ctx->ir_base[IR_FALSE].val.u64 = 0;
 	ctx->ir_base[IR_TRUE].optx = IR_OPT(IR_C_BOOL, IR_BOOL);
 	ctx->ir_base[IR_TRUE].val.u64 = 1;
+
+	ctx->ret_type = -1;
 }
 
 void ir_free(ir_ctx *ctx)


### PR DESCRIPTION
`ret_type` always needs to be initialized to -1 for all return builders to work, not sure why it is done separately (immediately after ir_init) in php-src, this moves the init inside of ir_init, thus fixing the examples.