### PR TITLE
netbsd support fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,14 @@ ifeq (FreeBSD, $(OS))
   LDFLAGS += -L/usr/local/lib
 endif
 
+ifeq (NetBSD, $(OS))
+  CC=cc
+  BUILD_CC=$(CC)
+  override CFLAGS += -I/usr/pkg/include
+  override BUILD_CFLAGS += -I/usr/pkg/include
+  LDFLAGS = -L/usr/pkg/lib -Wl,-rpath,/usr/pkg/lib -lm
+endif
+
 ifeq (yes, $(HAVE_LLVM))
   override CFLAGS += -DHAVE_LLVM
   LLVM_OBJS=$(BUILD_DIR)/ir_load_llvm.o

--- a/ir.c
+++ b/ir.c
@@ -1556,7 +1556,11 @@ int ir_mem_flush(void *ptr, size_t size)
 #else
 void *ir_mem_mmap(size_t size)
 {
-	void *ret = mmap(NULL, size, PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        int prot_flags = PROT_EXEC;
+#if defined(__NetBSD__)
+	prot_flags |= PROT_MPROTECT(PROT_READ|PROT_WRITE);
+#endif
+	void *ret = mmap(NULL, size, prot_flags, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	if (ret == MAP_FAILED) {
 		ret = NULL;
 	}


### PR DESCRIPTION
tests fails because of mapping permissions changes. they need to be pre authorized beforehand with PROT_MPROTECT macro.

while at it, easing netbsd build itself, unlike freebsd no fake libdl,
 capstone in /usr/pkg.