### PR TITLE
Improve make system

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,18 @@
+PREFIX  = /usr/local
+
+INC_DIR = $(PREFIX)/include
+LIB_DIR = $(PREFIX)/lib
+
+CC      = gcc
+CFLAGS  = -O0 -g -Wall -Wextra -Wno-unused-parameter -I$(INC_DIR)
+LDFLAGS = -L$(LIB_DIR) -lir -lcapstone
+
+EXAMPLE_EXES = mandelbrot 0001-basic 0002-while 0003-pointer 0004-func 0005-basic-runner-func
+
+all: $(EXAMPLE_EXES)
+
+$(EXAMPLE_EXES): $(notdir %): $(notdir %.c)
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+clean:
+	rm -rf $(EXAMPLE_EXES)

--- a/examples/mandelbrot.c
+++ b/examples/mandelbrot.c
@@ -7,9 +7,6 @@
 
 #include "ir.h"
 #include "ir_builder.h"
-#if defined(IR_TARGET_X86) || defined(IR_TARGET_X64)
-# include "ir_x86.h"
-#endif
 #include <stdlib.h>
 #include <string.h>
 #ifndef _WIN32

--- a/ir.h
+++ b/ir.h
@@ -36,6 +36,21 @@ extern "C" {
 # endif
 #endif
 
+/* target auto detection */
+#if !defined(IR_TARGET_X86) && !defined(IR_TARGET_X64) && !defined(IR_TARGET_AARCH64)
+# if defined(__x86_64__)
+#  define IR_TARGET_X64
+# elif defined(i386)
+#  define IR_TARGET_X86
+# elif defined (__aarch64__)
+#  define IR_TARGET_AARCH64
+# elif defined (_WIN64)
+#  define IR_TARGET_X64
+# elif defined (_WIN32)
+#  define IR_TARGET_X86
+# endif
+#endif
+
 #if defined(IR_TARGET_X86)
 # define IR_TARGET "x86"
 #elif defined(IR_TARGET_X64)


### PR DESCRIPTION
- allow IR_TARGET auto detection in ir.h
- add "libir.a" target
- add "install" and "uninstall" targets
- separate a simplified examples/Makefile
- remove useless dependencies from examples/mandelbrot.c