### PR TITLE
Fix IR JIT build with -Werror=strict-prototypes

### DIFF
--- a/gen_ir_fold_hash.c
+++ b/gen_ir_fold_hash.c
@@ -238,7 +238,7 @@ static int parse_rule(const char *buf)
 	return mask;
 }
 
-int main()
+int main(void)
 {
 	char buf[4096];
 	FILE *f = stdin;


### PR DESCRIPTION
This fixes warning when using -Wstrict-prototypes or -Werror=strict-prototypes.