### PR TITLE
Implement e-SSA PI nodes

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -1399,6 +1399,29 @@ bool ir_list_contains(const ir_list *l, ir_ref val)
 	return 0;
 }
 
+bool ir_remove_pis(ir_ctx *ctx)
+{
+	ir_ref n, i;
+	ir_insn *insn;
+
+	for (i = IR_UNUSED + 1, insn = ctx->ir_base + i; i < ctx->insns_count;) {
+		n = insn->inputs_count;
+
+		if (insn->op == IR_PI) {
+			ir_use_list_remove_all(ctx, insn->op2, i);
+			insn->op2 = IR_UNUSED;
+			insn->op = IR_COPY;
+			insn->inputs_count = 1;
+		}
+
+		n = ir_insn_inputs_to_len(n);
+		i += n;
+		insn += n;
+	}
+
+	return true;
+}
+
 static uint32_t ir_hashtab_hash_size(uint32_t size)
 {
 	size -= 1;

--- a/ir_builder.h
+++ b/ir_builder.h
@@ -471,6 +471,12 @@ extern "C" {
 #define ir_PHI_N(type, _n, _inputs)       _ir_PHI_N(_ir_CTX, type, (_n), (_inputs))
 #define ir_PHI_SET_OP(_ref, _pos, _src)   _ir_PHI_SET_OP(_ir_CTX, (_ref), (_pos), (_src))
 
+// TODO: typed builders
+#define ir_PI(_type, _ref, _range)        ir_BINARY_OP(IR_PI, (_type), (_ref), (_range))
+
+// TODO: typed builders
+#define ir_RANGE(_type, _min, _max)       ir_BINARY_OP(IR_PI, (_type), (_min), (_max))
+
 #define ir_COPY(_type, _op1)              ir_UNARY_OP(IR_COPY, (_type), (_op1))
 #define ir_COPY_B(_op1)                   ir_UNARY_OP_B(IR_COPY, (_op1))
 #define ir_COPY_U8(_op1)                  ir_UNARY_OP_U8(IR_COPY, (_op1))

--- a/ir_check.c
+++ b/ir_check.c
@@ -191,6 +191,13 @@ bool ir_check(const ir_ctx *ctx)
 												i, j, use, use_insn->type, insn->type);
 											ok = 0;
 										}
+										if (insn->op == IR_PI) {
+											if (j == 2 && use_insn->op != IR_RANGE) {
+												fprintf(stderr, "ir_base[%d].ops[%d] (%d) op must be RANGE (%d)\n",
+													i, j, use_insn->op, IR_RANGE);
+												ok = 0;
+											}
+										}
 										break;
 								}
 							}

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -407,7 +407,7 @@ static void ir_emit_bitcast(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 			fprintf(f, " = _u.d;}\n");
 		} else {
 			IR_ASSERT(insn->type == IR_FLOAT);
-			fprintf(f, "\t{union {float f; uint32_t bits;} _u; _u.buts = ");
+			fprintf(f, "\t{union {float f; uint32_t bits;} _u; _u.bits = ");
 			ir_emit_ref(ctx, f, insn->op1);
 			fprintf(f, "; ");
 			ir_emit_ref(ctx, f, def);

--- a/ir_fold.h
+++ b/ir_fold.h
@@ -1352,6 +1352,24 @@ IR_FOLD(FP2FP(C_DOUBLE))
 	}
 }
 
+IR_FOLD(PI(C_BOOL, _))
+IR_FOLD(PI(C_U8, _))
+IR_FOLD(PI(C_U16, _))
+IR_FOLD(PI(C_U32, _))
+IR_FOLD(PI(C_U64, _))
+IR_FOLD(PI(C_ADDR, _))
+IR_FOLD(PI(C_CHAR, _))
+IR_FOLD(PI(C_I8, _))
+IR_FOLD(PI(C_I16, _))
+IR_FOLD(PI(C_I32, _))
+IR_FOLD(PI(C_I64, _))
+IR_FOLD(PI(C_DOUBLE, _))
+IR_FOLD(PI(C_FLOAT, _))
+IR_FOLD(PI(C_U64, _))
+{
+	IR_FOLD_COPY(op1);
+}
+
 // TODO: constant functions (e.g.  sin, cos)
 
 /* Copy Propagation */
@@ -1424,6 +1442,103 @@ IR_FOLD(BSWAP(BSWAP))
 {
 	/* f(f(y)) => y */
 	IR_FOLD_COPY(op1_insn->op1);
+}
+
+IR_FOLD(EQ(PI, C_BOOL))
+IR_FOLD(EQ(PI, C_U8))
+IR_FOLD(EQ(PI, C_U16))
+IR_FOLD(EQ(PI, C_U32))
+IR_FOLD(EQ(PI, C_U64))
+IR_FOLD(EQ(PI, C_ADDR))
+{
+	ir_insn *range_insn = &ctx->ir_base[op1_insn->op2];
+	IR_ASSERT(range_insn->op == IR_RANGE);
+	if (IR_IS_CONST_REF(range_insn->op1)) {
+		if (op2_insn->val.u64 < ctx->ir_base[range_insn->op1].val.u64) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op2)) {
+		if (op2_insn->val.u64 > ctx->ir_base[range_insn->op2].val.u64) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op1) && IR_IS_CONST_REF(range_insn->op2)) {
+		if (ctx->ir_base[range_insn->op1].val.u64 == ctx->ir_base[range_insn->op2].val.u64) {
+			IR_FOLD_COPY(IR_TRUE);
+		}
+	}
+	IR_FOLD_NEXT;
+}
+
+IR_FOLD(EQ(PI, C_CHAR))
+IR_FOLD(EQ(PI, C_I8))
+IR_FOLD(EQ(PI, C_I16))
+IR_FOLD(EQ(PI, C_I32))
+IR_FOLD(EQ(PI, C_I64))
+{
+	ir_insn *range_insn = &ctx->ir_base[op1_insn->op2];
+	IR_ASSERT(range_insn->op == IR_RANGE);
+	if (IR_IS_CONST_REF(range_insn->op1)) {
+		if (op2_insn->val.i64 < ctx->ir_base[range_insn->op1].val.i64) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op2)) {
+		if (op2_insn->val.i64 > ctx->ir_base[range_insn->op2].val.i64) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op1) && IR_IS_CONST_REF(range_insn->op2)) {
+		if (ctx->ir_base[range_insn->op1].val.i64 == ctx->ir_base[range_insn->op2].val.i64) {
+			IR_FOLD_COPY(IR_TRUE);
+		}
+	}
+	IR_FOLD_NEXT;
+}
+
+IR_FOLD(PI(_, C_DOUBLE))
+{
+	ir_insn *range_insn = &ctx->ir_base[op1_insn->op2];
+	IR_ASSERT(range_insn->op == IR_RANGE);
+	if (IR_IS_CONST_REF(range_insn->op1)) {
+		if (op2_insn->val.d < ctx->ir_base[range_insn->op1].val.d) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op2)) {
+		if (op2_insn->val.d > ctx->ir_base[range_insn->op2].val.d) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op1) && IR_IS_CONST_REF(range_insn->op2)) {
+		if (ctx->ir_base[range_insn->op1].val.d == ctx->ir_base[range_insn->op2].val.d) {
+			IR_FOLD_COPY(IR_TRUE);
+		}
+	}
+	IR_FOLD_NEXT;
+}
+
+IR_FOLD(PI(_, C_FLOAT))
+{
+	ir_insn *range_insn = &ctx->ir_base[op1_insn->op2];
+	IR_ASSERT(range_insn->op == IR_RANGE);
+	if (IR_IS_CONST_REF(range_insn->op1)) {
+		if (op2_insn->val.f < ctx->ir_base[range_insn->op1].val.f) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op2)) {
+		if (op2_insn->val.f > ctx->ir_base[range_insn->op2].val.f) {
+			IR_FOLD_COPY(IR_FALSE);
+		}
+	}
+	if (IR_IS_CONST_REF(range_insn->op1) && IR_IS_CONST_REF(range_insn->op2)) {
+		if (ctx->ir_base[range_insn->op1].val.f == ctx->ir_base[range_insn->op2].val.f) {
+			IR_FOLD_COPY(IR_TRUE);
+		}
+	}
+	IR_FOLD_NEXT;
 }
 
 IR_FOLD(EQ(_, C_BOOL))

--- a/ir_main.c
+++ b/ir_main.c
@@ -222,6 +222,8 @@ int ir_compile_func(ir_ctx *ctx, int opt_level, uint32_t save_flags, uint32_t du
 #endif
 	}
 
+	ir_remove_pis(ctx);
+
 	if (opt_level > 0 || (ctx->flags & (IR_GEN_NATIVE|IR_GEN_CODE))) {
 		ir_build_cfg(ctx);
 		if ((dump & (IR_DUMP_AFTER_CFG|IR_DUMP_AFTER_ALL))

--- a/ir_private.h
+++ b/ir_private.h
@@ -525,6 +525,7 @@ IR_ALWAYS_INLINE int ir_bitqueue_pop(ir_bitqueue *q)
 
 IR_ALWAYS_INLINE void ir_bitqueue_add(ir_bitqueue *q, uint32_t n)
 {
+	IR_ASSERT(n > 0);
 	uint32_t i = n / IR_BITSET_BITS;
 	q->set[i] |= IR_BITSET_ONE << (n % IR_BITSET_BITS);
 	if (i < q->pos) {

--- a/tests/dead_guard_001.irt
+++ b/tests/dead_guard_001.irt
@@ -1,0 +1,28 @@
+--TEST--
+001: Dead guard
+--CODE--
+{
+	int32_t d_1 = 0;
+	uintptr_t d_2 = 0;
+	uintptr_t d_3 = 1;
+	l_1 = START(l_12);
+	int32_t d_4 = PARAM(l_1, "x", 0);
+	bool d_5 = EQ(d_4, d_2);
+	l_4 = GUARD(l_1, d_4, d_1);
+	int32_t d_6 = RANGE(d_2, d_2);
+	int32_t d_7 = PI(d_4, d_6);
+	bool d_8 = EQ(d_7, d_2);
+	l_5 = GUARD(l_4, d_8, d_1);
+	l_12 = RETURN(l_5);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int32_t c_4 = 0;
+	l_1 = START(l_4);
+	int32_t d_2 = PARAM(l_1, "x", 0);
+	l_3 = GUARD(l_1, d_2, c_4);
+	l_4 = RETURN(l_3, null);
+}

--- a/tests/folding/fold_014.irt
+++ b/tests/folding/fold_014.irt
@@ -1,0 +1,21 @@
+--TEST--
+014: FOLD: PI(A, CONST) => CONST
+--CODE--
+{
+	l_1 = START(l_6);
+	int32_t d_1 = 2;
+	int32_t d_2 = 1;
+	int32_t d_3 = ADD(d_2, d_2);
+	int32_t d_4 = RANGE(d_2, d_1);
+	int32_t d_5 = PI(d_3, d_4);
+	l_6 = RETURN(l_1, d_5);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int32_t c_4 = 2;
+	l_1 = START(l_2);
+	l_2 = RETURN(l_1, c_4);
+}

--- a/tests/folding/fold_015.irt
+++ b/tests/folding/fold_015.irt
@@ -1,0 +1,25 @@
+--TEST--
+015: FOLD: EQ(PI(A, [Y..Z]), Y) => EQ(_)
+--CODE--
+{
+	int32_t d_1 = 1;
+	int32_t d_2 = 2;
+	l_1 = START(l_6);
+	int32_t d_3 = PARAM(l_1, "x", 1);
+	int32_t d_4 = RANGE(d_1, d_2);
+	int32_t d_5 = PI(d_3, d_4);
+	bool d_6 = EQ(d_5, d_1);
+	l_6 = RETURN(l_1, d_6);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int32_t c_4 = 1;
+	l_1 = START(l_5);
+	int32_t d_2 = PARAM(l_1, "x", 1);
+	int32_t d_3 = COPY(d_2);
+	bool d_4 = EQ(d_3, c_4);
+	l_5 = RETURN(l_1, d_4);
+}

--- a/tests/folding/fold_016.irt
+++ b/tests/folding/fold_016.irt
@@ -1,0 +1,23 @@
+--TEST--
+016: FOLD: EQ(PI(A, [Y..Z]), X) => FALSE
+--CODE--
+{
+	int32_t d_0 = 0;
+	int32_t d_1 = 1;
+	int32_t d_2 = 2;
+	l_1 = START(l_6);
+	int32_t d_3 = PARAM(l_1, "x", 1);
+	int32_t d_4 = RANGE(d_1, d_2);
+	int32_t d_5 = PI(d_3, d_4);
+	bool d_6 = EQ(d_5, d_0);
+	l_6 = RETURN(l_1, d_6);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_3);
+	int32_t d_2 = PARAM(l_1, "x", 1);
+	l_3 = RETURN(l_1, c_2);
+}

--- a/tests/folding/fold_017.irt
+++ b/tests/folding/fold_017.irt
@@ -1,0 +1,23 @@
+--TEST--
+017: FOLD: EQ(PI(A, [X..Y]), Z) => FALSE
+--CODE--
+{
+	int32_t d_0 = 0;
+	int32_t d_1 = 1;
+	int32_t d_2 = 2;
+	l_1 = START(l_6);
+	int32_t d_3 = PARAM(l_1, "x", 1);
+	int32_t d_4 = RANGE(d_0, d_1);
+	int32_t d_5 = PI(d_3, d_4);
+	bool d_6 = EQ(d_5, d_2);
+	l_6 = RETURN(l_1, d_6);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_3);
+	int32_t d_2 = PARAM(l_1, "x", 1);
+	l_3 = RETURN(l_1, c_2);
+}

--- a/tests/folding/fold_018.irt
+++ b/tests/folding/fold_018.irt
@@ -1,0 +1,21 @@
+--TEST--
+018: FOLD: EQ(PI(A, [X..X]), X) => TRUE
+--CODE--
+{
+	int32_t d_0 = 0;
+	l_1 = START(l_6);
+	int32_t d_1 = PARAM(l_1, "x", 1);
+	int32_t d_2 = RANGE(d_0, d_0);
+	int32_t d_3 = PI(d_1, d_2);
+	bool d_4 = EQ(d_3, d_0);
+	l_6 = RETURN(l_1, d_4);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_3);
+	int32_t d_2 = PARAM(l_1, "x", 1);
+	l_3 = RETURN(l_1, c_3);
+}


### PR DESCRIPTION
This implements e-SSA PI constraint nodes, without range propagation.

This uses the folding engine to replace comparison ops into constants when possible, and in turn the SCCP engine can elide IF/SWITCH/GUARD. I only implemented folding for `EQ` right now, but I will add other ops. I also did not add support for symbolic ranges.

PI node signature has the form `PI(def, RANGE(min, max))` (op2 is a RANGE op). It should be possible to change this to `PI(def, min, max)`, but the folding engine supports only two operands currently.

PI nodes must be added manually, like PHI nodes. They are replaced by COPY ops after SCCP so that other passes do not have to be aware of them.