### PR TITLE
Add support for AArch64 FreeBSD dynamic TLS

### DIFF
--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -5239,8 +5239,18 @@ static void ir_emit_tls(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 ||#else
 ||	code = 0xd53bd040 | reg; // TODO: hard-coded: mrs reg, tpidr_el0
 |	.long code
+||# ifdef __FreeBSD__
+||	if (insn->op3 == IR_NULL) {
+|		ldr Rx(reg), [Rx(reg), #insn->op2]
+||	} else {
+|		ldr Rx(reg), [Rx(reg), #0]
+|		ldr Rx(reg), [Rx(reg), #insn->op2]
+|		ldr Rx(reg), [Rx(reg), #insn->op3]
+||	}
+||# else
 ||//???	IR_ASSERT(insn->op2 <= LDR_STR_PIMM64);
 |	ldr Rx(reg), [Rx(reg), #insn->op2]
+||# endif
 ||#endif
 	if (IR_REG_SPILLED(ctx->regs[def][0])) {
 		ir_emit_store(ctx, IR_ADDR, def, reg);


### PR DESCRIPTION
This change is necessary to support https://github.com/php/php-src/pull/11236 for IR JIT. Currently that PR is only for 8.2-8.3 but I plan on adding IR JIT support once this is merged.