### PR TITLE
Sync IR_DEBUG conditions - #if/ifdef/defined (-Wundef)

### DIFF
--- a/ir_emit.c
+++ b/ir_emit.c
@@ -41,7 +41,7 @@
 
 #define DASM_M_FREE(ctx, p, sz) ir_mem_free(p)
 
-#if IR_DEBUG
+#ifdef IR_DEBUG
 # define DASM_CHECKS
 #endif
 

--- a/ir_ra.c
+++ b/ir_ra.c
@@ -2771,7 +2771,7 @@ static void ir_merge_to_unhandled(ir_live_interval **unhandled, ir_live_interval
 			ival = ival->next;
 		}
 	}
-#if IR_DEBUG
+#ifdef IR_DEBUG
 	ival = *unhandled;
 	pos = 0;
 


### PR DESCRIPTION
IR_DEBUG can be either undefined or defined (to value 1).