### PR TITLE
Sync DISASM_INTEL_SYNTAX condition #if/ifdef/defined (-Wundef)

### DIFF
--- a/ir_disasm.c
+++ b/ir_disasm.c
@@ -29,6 +29,10 @@
 #include <capstone/capstone.h>
 #define HAVE_CAPSTONE_ITER
 
+#ifndef IR_DISASM_INTEL_SYNTAX
+# define IR_DISASM_INTEL_SYNTAX 0
+#endif
+
 typedef struct _ir_sym_node {
 	uint64_t             addr;
 	uint64_t             end;
@@ -365,7 +369,7 @@ int ir_disasm(const char    *name,
 	}
 #  endif
 	cs_option(cs, CS_OPT_DETAIL, CS_OPT_ON);
-#  ifdef DISASM_INTEL_SYNTAX
+#  if IR_DISASM_INTEL_SYNTAX
 	cs_option(cs, CS_OPT_SYNTAX, CS_OPT_SYNTAX_INTEL);
 #  else
 	cs_option(cs, CS_OPT_SYNTAX, CS_OPT_SYNTAX_ATT);

--- a/ir_disasm.c
+++ b/ir_disasm.c
@@ -365,7 +365,7 @@ int ir_disasm(const char    *name,
 	}
 #  endif
 	cs_option(cs, CS_OPT_DETAIL, CS_OPT_ON);
-#  if DISASM_INTEL_SYNTAX
+#  ifdef DISASM_INTEL_SYNTAX
 	cs_option(cs, CS_OPT_SYNTAX, CS_OPT_SYNTAX_INTEL);
 #  else
 	cs_option(cs, CS_OPT_SYNTAX, CS_OPT_SYNTAX_ATT);


### PR DESCRIPTION
For this one I'm not sure what would be better here. To define it to 0 or to do the `#ifdef`. In PHP <= 8.3 JIT engine there was also this one used but disabled with value 0.