### PR TITLE
Use external __jit_debug_descriptor when IR_EXTERNAL_GDB_ENTRY is defined

### DIFF
--- a/ir_gdb.c
+++ b/ir_gdb.c
@@ -500,13 +500,14 @@ typedef struct _ir_gdbjit_descriptor {
 	struct _ir_gdbjit_code_entry *first_entry;
 } ir_gdbjit_descriptor;
 
+#ifdef IR_EXTERNAL_GDB_ENTRY
+extern ir_gdbjit_descriptor __jit_debug_descriptor;
+void __jit_debug_register_code(void);
+#else
 ir_gdbjit_descriptor __jit_debug_descriptor = {
 	1, IR_GDBJIT_NOACTION, NULL, NULL
 };
 
-#ifdef IR_EXTERNAL_GDB_ENTRY
-void __jit_debug_register_code(void);
-#else
 IR_NEVER_INLINE void __jit_debug_register_code(void)
 {
 	__asm__ __volatile__("");


### PR DESCRIPTION
If there are multiple `__jit_debug_descriptor` symbols, GDB may pick any, and `ir_gdb_register_code()` has no effect.