### PR TITLE
Do not define IR_EXTERNAL_GDB_ENTRY in ir_php.h

### DIFF
--- a/ir_php.h
+++ b/ir_php.h
@@ -30,8 +30,4 @@
 # define ir_mem_free    efree
 #endif
 
-#if defined(IR_TARGET_AARCH64)
-# define IR_EXTERNAL_GDB_ENTRY
-#endif
-
 #endif /* IR_PHP_H */


### PR DESCRIPTION
This is a follow-up of https://github.com/dstogov/ir/pull/93.

I think that `IR_EXTERNAL_GDB_ENTRY` should always be defined for PHP.

I propose to the definition from `ir_php.h` so that it can always be defined [here](https://github.com/php/php-src/pull/16283/files).

Alternatively it could be defined unconditionally in `ir_php.h`.