### PR TITLE
Fixes for building with clang-cl on Windows

### DIFF
--- a/ir.h
+++ b/ir.h
@@ -29,7 +29,9 @@ extern "C" {
 # endif
 /* Only supported is little endian for any arch on Windows,
    so just fake the same for all. */
-# define __ORDER_LITTLE_ENDIAN__ 1
+# ifndef __ORDER_LITTLE_ENDIAN__
+#  define __ORDER_LITTLE_ENDIAN__ 1
+# endif
 # define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
 # ifndef __has_builtin
 #  define __has_builtin(arg) (0)

--- a/ir_emit.c
+++ b/ir_emit.c
@@ -272,10 +272,10 @@ static bool ir_is_same_mem_var(const ir_ctx *ctx, ir_ref r1, int32_t offset)
 
 void *ir_resolve_sym_name(const char *name)
 {
-	void *handle = NULL;
 	void *addr;
 
 #ifndef _WIN32
+	void *handle = NULL;
 # ifdef RTLD_DEFAULT
 	handle = RTLD_DEFAULT;
 # endif

--- a/ir_private.h
+++ b/ir_private.h
@@ -137,9 +137,10 @@ IR_ALWAYS_INLINE uint32_t ir_ntz(uint32_t num)
 /* Number of trailing zero bits (0x01 -> 0; 0x40 -> 6; 0x00 -> LEN) */
 IR_ALWAYS_INLINE uint32_t ir_ntzl(uint64_t num)
 {
-#if (defined(__GNUC__) || __has_builtin(__builtin_ctzl))
-	return __builtin_ctzl(num);
-#elif defined(_WIN64)
+  // Note that the _WIN64 case should come before __has_builtin() below so that
+  // clang-cl on Windows will use the uint64_t version, not the "long" uint32_t
+  // version.
+#if defined(_WIN64)
 	unsigned long index;
 
 	if (!_BitScanForward64(&index, num)) {
@@ -148,6 +149,8 @@ IR_ALWAYS_INLINE uint32_t ir_ntzl(uint64_t num)
 	}
 
 	return (uint32_t) index;
+#elif (defined(__GNUC__) || __has_builtin(__builtin_ctzl))
+	return __builtin_ctzl(num);
 #else
 	uint32_t n;
 


### PR DESCRIPTION
The first two commits are just minor incompatibilities in the compiler, but the ntzl one caused incorrect behaviour in `ir_bitqueue_pop()`.