### PR TITLE
Propagate code_buffer when creating a new ir_ctx in ir_schedule

### DIFF
--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -1328,11 +1328,13 @@ restart:
 	new_ctx.cfg_edges = ctx->cfg_edges;
 	ctx->cfg_blocks = NULL;
 	ctx->cfg_edges = NULL;
+	ir_code_buffer *saved_code_buffer = ctx->code_buffer;
 
 	ir_free(ctx);
 	IR_ASSERT(new_ctx.consts_count == new_ctx.consts_limit);
 	IR_ASSERT(new_ctx.insns_count == new_ctx.insns_limit);
 	memcpy(ctx, &new_ctx, sizeof(ir_ctx));
+	ctx->code_buffer = saved_code_buffer;
 	ctx->flags2 |= IR_LINEAR;
 
 	ir_mem_free(_next);


### PR DESCRIPTION
A trimmed ir_ctx is created during ir_schedule(), but this loses a user-provided code_buffer if one was in the original ir_ctx.

When code_buffer isn't provided, the many VirtualAlloc calls when compiling lots of small functions take ~70% of the total runtime in my compiler. (!)