### PR TITLE
Fix php/php-src#17966: Symfony JIT 1205 assertion failure

### DIFF
--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -401,9 +401,10 @@ static bool ir_split_partially_dead_node(ir_ctx *ctx, ir_ref ref, uint32_t b)
 	for (i = 1; i < clones_count; i++) {
 		clones[i].ref = clone = ir_emit(ctx, insn->optx, insn->op1, insn->op2, insn->op3);
 		insn = &ctx->ir_base[ref];
-		if (insn->op1 > 0) ir_use_list_add(ctx, insn->op1, clone);
-		if (insn->op2 > 0) ir_use_list_add(ctx, insn->op2, clone);
-		if (insn->op3 > 0) ir_use_list_add(ctx, insn->op3, clone);
+		/* Depending on the flags in IR_OPS, these can be references or data. */
+		if (insn->op1 > 0 && insn->inputs_count >= 1) ir_use_list_add(ctx, insn->op1, clone);
+		if (insn->op2 > 0 && insn->inputs_count >= 2) ir_use_list_add(ctx, insn->op2, clone);
+		if (insn->op3 > 0 && insn->inputs_count >= 3) ir_use_list_add(ctx, insn->op3, clone);
 	}
 
 	/* Reconstruct IR: Update DEF->USE lists, CFG mapping and etc */


### PR DESCRIPTION
In this [example code](https://github.com/php/php-src/issues/17966),
`ir_split_partially_dead_node()` tries to create a clone of an IR_COPY instruction, but that instruction has an extra data op in op2. IR tries to add uses to op2 but it's not actually a real ir_ref. In this case, op2 is the number 1; if it were an ir_ref it would correspond to the IR_START node, which seems wrong. This patch adds an extra check to see if it's a real input.

I'm not sure this is fully right, or if this is the best way to fix it. Happy to take advice.

This was blocking me from making further measurements on https://github.com/php/php-src/pull/17909