### PR TITLE
Include generated files from the include path

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -918,7 +918,7 @@ static ir_ref _ir_fold_cse(ir_ctx *ctx, uint32_t opt, ir_ref op1, ir_ref op2, ir
 #define IR_FOLD_EMIT           goto ir_fold_emit
 #define IR_FOLD_NEXT           break
 
-#include "ir_fold_hash.h"
+#include <ir_fold_hash.h>
 
 #define IR_FOLD_RULE(x) ((x) >> 21)
 #define IR_FOLD_KEY(x)  ((x) & 0x1fffff)

--- a/ir_emit.c
+++ b/ir_emit.c
@@ -415,9 +415,9 @@ static int ir_const_label(ir_ctx *ctx, ir_ref ref)
 }
 
 #if defined(IR_TARGET_X86) || defined(IR_TARGET_X64)
-# include "ir_emit_x86.h"
+# include <ir_emit_x86.h>
 #elif defined(IR_TARGET_AARCH64)
-# include "ir_emit_aarch64.h"
+# include <ir_emit_aarch64.h>
 #else
 # error "Unknown IR target"
 #endif


### PR DESCRIPTION
Using `#include "generated-file.h"` searches in the directory containing the file being compiled. When compiling out of the source dir, this may include the wrong file (e.g. a stalled, previously generated file in the source dir).

Using `#include <generated-file.h>` ensures that we search the file in the include path first, which may give priority to the build dir.