### PR TITLE
Prevent clobbering of TAILCALL op2 in epilogue

### DIFF
--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -4943,6 +4943,26 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 		return;
 	}
 
+	/* Move op2 to a tmp register before epilogue if it's in
+	 * used_preserved_regs, because it will be overridden. */
+
+	ir_reg op2_reg = IR_REG_NONE;
+	if (!IR_IS_CONST_REF(insn->op2)) {
+		op2_reg = ctx->regs[def][2];
+
+		IR_ASSERT(op2_reg != IR_REG_NONE);
+		if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
+			ir_reg orig_op2_reg = IR_REG_NUM(op2_reg);
+			op2_reg = IR_REG_INT_TMP;
+			if (IR_REG_SPILLED(orig_op2_reg)) {
+				ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
+			} else {
+				ir_type type = ctx->ir_base[insn->op2].type;
+				| ASM_REG_REG_OP mov, type, op2_reg, orig_op2_reg
+			}
+		}
+	}
+
 	ir_emit_epilogue(ctx);
 
 	if (IR_IS_CONST_REF(insn->op2)) {
@@ -4955,13 +4975,8 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 			|	br Rx(IR_REG_INT_TMP)
 		}
     } else {
-		ir_reg op2_reg = ctx->regs[def][2];
-
 		IR_ASSERT(op2_reg != IR_REG_NONE);
-		if (IR_REG_SPILLED(op2_reg)) {
-			op2_reg = IR_REG_NUM(op2_reg);
-			ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
-		}
+		IR_ASSERT(!IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, op2_reg));
 		|	br Rx(op2_reg)
     }
 }

--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -4951,15 +4951,17 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 		op2_reg = ctx->regs[def][2];
 		IR_ASSERT(op2_reg != IR_REG_NONE);
 
-		if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
+		if (IR_REG_SPILLED(op2_reg)) {
+			op2_reg = IR_REG_INT_TMP;
+			ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
+		} else if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
 			ir_reg orig_op2_reg = op2_reg;
 			op2_reg = IR_REG_INT_TMP;
-			if (IR_REG_SPILLED(orig_op2_reg)) {
-				ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
-			} else {
-				ir_type type = ctx->ir_base[insn->op2].type;
-				| ASM_REG_REG_OP mov, type, op2_reg, IR_REG_NUM(orig_op2_reg)
-			}
+
+			ir_type type = ctx->ir_base[insn->op2].type;
+			| ASM_REG_REG_OP mov, type, op2_reg, IR_REG_NUM(orig_op2_reg)
+		} else {
+			op2_reg = IR_REG_NUM(op2_reg);
 		}
 	}
 

--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -4949,16 +4949,16 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 	ir_reg op2_reg = IR_REG_NONE;
 	if (!IR_IS_CONST_REF(insn->op2)) {
 		op2_reg = ctx->regs[def][2];
-
 		IR_ASSERT(op2_reg != IR_REG_NONE);
+
 		if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
-			ir_reg orig_op2_reg = IR_REG_NUM(op2_reg);
+			ir_reg orig_op2_reg = op2_reg;
 			op2_reg = IR_REG_INT_TMP;
 			if (IR_REG_SPILLED(orig_op2_reg)) {
 				ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
 			} else {
 				ir_type type = ctx->ir_base[insn->op2].type;
-				| ASM_REG_REG_OP mov, type, op2_reg, orig_op2_reg
+				| ASM_REG_REG_OP mov, type, op2_reg, IR_REG_NUM(orig_op2_reg)
 			}
 		}
 	}

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -9237,16 +9237,21 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 	if (!IR_IS_CONST_REF(insn->op2)) {
 		op2_reg = ctx->regs[def][2];
 
+		ir_regset preserved_regs = (ir_regset)ctx->used_preserved_regs | IR_REGSET(IR_REG_STACK_POINTER);
+		if (ctx->flags & IR_USE_FRAME_POINTER) {
+			preserved_regs |= IR_REGSET(IR_REG_FRAME_POINTER);
+		}
+
 		if (op2_reg != IR_REG_NONE) {
-			if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
-				ir_reg orig_op2_reg = IR_REG_NUM(op2_reg);
+			if (IR_REGSET_IN(preserved_regs, IR_REG_NUM(op2_reg))) {
+				ir_ref orig_op2_reg = op2_reg;
 				op2_reg = IR_REG_RAX;
 
 				if (IR_REG_SPILLED(orig_op2_reg)) {
 					ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
 				} else {
 					ir_type type = ctx->ir_base[insn->op2].type;
-					| ASM_REG_REG_OP mov, type, op2_reg, orig_op2_reg
+					| ASM_REG_REG_OP mov, type, op2_reg, IR_REG_NUM(orig_op2_reg)
 				}
 			}
 		} else {
@@ -9257,8 +9262,8 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 			}
 			ir_reg base = IR_MEM_BASE(mem);
 			ir_reg index = IR_MEM_INDEX(mem);
-			if ((base != IR_REG_NONE && IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, base)) ||
-					(index != IR_REG_NONE && IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, index))) {
+			if ((base != IR_REG_NONE && IR_REGSET_IN(preserved_regs, base)) ||
+					(index != IR_REG_NONE && IR_REGSET_IN(preserved_regs, index))) {
 				op2_reg = IR_REG_RAX;
 
 				ir_type type = ctx->ir_base[insn->op2].type;

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -9229,6 +9229,44 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 		return;
 	}
 
+	/* Move op2 to a tmp register before epilogue if it's in
+	 * used_preserved_regs, because it will be overridden. */
+
+	ir_reg op2_reg = IR_REG_NONE;
+	ir_mem mem = IR_MEM_B(IR_REG_NONE);
+	if (!IR_IS_CONST_REF(insn->op2)) {
+		op2_reg = ctx->regs[def][2];
+
+		if (op2_reg != IR_REG_NONE) {
+			if (IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, IR_REG_NUM(op2_reg))) {
+				ir_reg orig_op2_reg = IR_REG_NUM(op2_reg);
+				op2_reg = IR_REG_RAX;
+
+				if (IR_REG_SPILLED(orig_op2_reg)) {
+					ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
+				} else {
+					ir_type type = ctx->ir_base[insn->op2].type;
+					| ASM_REG_REG_OP mov, type, op2_reg, orig_op2_reg
+				}
+			}
+		} else {
+			if (ir_rule(ctx, insn->op2) & IR_FUSED) {
+				mem = ir_fuse_load(ctx, def, insn->op2);
+			} else {
+				mem = ir_ref_spill_slot(ctx, insn->op2);
+			}
+			ir_reg base = IR_MEM_BASE(mem);
+			ir_reg index = IR_MEM_INDEX(mem);
+			if ((base != IR_REG_NONE && IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, base)) ||
+					(index != IR_REG_NONE && IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, index))) {
+				op2_reg = IR_REG_RAX;
+
+				ir_type type = ctx->ir_base[insn->op2].type;
+				| ASM_REG_MEM_OP, mov, type, op2_reg, mem
+			}
+		}
+	}
+
 	ir_emit_epilogue(ctx);
 
 	if (IR_IS_CONST_REF(insn->op2)) {
@@ -9254,22 +9292,10 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 |.endif
 		}
     } else {
-		ir_reg op2_reg = ctx->regs[def][2];
-
 		if (op2_reg != IR_REG_NONE) {
-			if (IR_REG_SPILLED(op2_reg)) {
-				op2_reg = IR_REG_NUM(op2_reg);
-				ir_emit_load(ctx, IR_ADDR, op2_reg, insn->op2);
-			}
+			IR_ASSERT(!IR_REGSET_IN((ir_regset)ctx->used_preserved_regs, op2_reg));
 			|	jmp Ra(op2_reg)
 		} else {
-			ir_mem mem;
-
-			if (ir_rule(ctx, insn->op2) & IR_FUSED) {
-				mem = ir_fuse_load(ctx, def, insn->op2);
-			} else {
-				mem = ir_ref_spill_slot(ctx, insn->op2);
-			}
 			|	ASM_TMEM_OP jmp, aword, mem
 		}
     }

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -9262,7 +9262,7 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 				op2_reg = IR_REG_RAX;
 
 				ir_type type = ctx->ir_base[insn->op2].type;
-				| ASM_REG_MEM_OP, mov, type, op2_reg, mem
+				ir_emit_load_mem_int(ctx, type, op2_reg, mem);
 			}
 		}
 	}

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -9242,7 +9242,11 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 			preserved_regs |= IR_REGSET(IR_REG_FRAME_POINTER);
 		}
 
-		if (op2_reg != IR_REG_NONE) {
+		bool is_spill_slot = op2_reg != IR_REG_NONE
+			&& IR_REG_SPILLED(op2_reg)
+			&& ctx->vregs[insn->op2];
+
+		if (op2_reg != IR_REG_NONE && !is_spill_slot) {
 			if (IR_REGSET_IN(preserved_regs, IR_REG_NUM(op2_reg))) {
 				ir_ref orig_op2_reg = op2_reg;
 				op2_reg = IR_REG_RAX;
@@ -9253,9 +9257,12 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 					ir_type type = ctx->ir_base[insn->op2].type;
 					| ASM_REG_REG_OP mov, type, op2_reg, IR_REG_NUM(orig_op2_reg)
 				}
+			} else {
+				op2_reg = IR_REG_NUM(op2_reg);
 			}
 		} else {
 			if (ir_rule(ctx, insn->op2) & IR_FUSED) {
+				IR_ASSERT(op2_reg == IR_REG_NONE);
 				mem = ir_fuse_load(ctx, def, insn->op2);
 			} else {
 				mem = ir_ref_spill_slot(ctx, insn->op2);
@@ -9268,6 +9275,8 @@ static void ir_emit_tailcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 
 				ir_type type = ctx->ir_base[insn->op2].type;
 				ir_emit_load_mem_int(ctx, type, op2_reg, mem);
+			} else {
+				op2_reg = IR_REG_NONE;
 			}
 		}
 	}

--- a/tests/aarch64/tailcall_001.irt
+++ b/tests/aarch64/tailcall_001.irt
@@ -1,0 +1,25 @@
+--TEST--
+001: tailcall: epilogue does not override op2
+--TARGET--
+aarch64
+--ARGS--
+-S
+--CODE--
+{
+	l_1 = START(l_4);
+	uintptr_t f = PARAM(l_1, "p", 1);
+	l_2 = CALL(l_1, f);
+	l_3 = TAILCALL(l_2, f);
+	l_4 = UNREACHABLE(l_3);
+}
+--EXPECT--
+test:
+	stp x29, x30, [sp, #-0x20]!
+	mov x29, sp
+	str x19, [x29, #0x18]
+	mov x19, x0
+	blr x19
+	mov x17, x19
+	ldr x19, [x29, #0x18]
+	ldp x29, x30, [sp], #0x20
+	br x17

--- a/tests/aarch64/tailcall_002.irt
+++ b/tests/aarch64/tailcall_002.irt
@@ -1,0 +1,34 @@
+--TEST--
+002: tailcall: epilogue does not override op2: spilled non-preserved reg
+--TARGET--
+aarch64
+--ARGS--
+-S --debug-regset 0x00000001
+--CODE--
+# debug-regset: X0
+{
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	sub sp, sp, #0x10
+	str x0, [sp]
+	add x0, x0, x0
+	cmp x0, #0
+	b.eq .L1
+	ldr x17, [sp]
+	add sp, sp, #0x10
+	br x17
+.L1:
+	ldr x0, [sp]
+	add sp, sp, #0x10
+	ret
+

--- a/tests/aarch64/tailcall_003.irt
+++ b/tests/aarch64/tailcall_003.irt
@@ -1,0 +1,37 @@
+--TEST--
+003: tailcall: epilogue does not override op2: spilled preserved reg
+--TARGET--
+aarch64
+--ARGS--
+-S --debug-regset 0x00080000
+--CODE--
+# debug-regset: X19
+{
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	sub sp, sp, #0x10
+	str x19, [sp, #8]
+	mov x19, x0
+	str x19, [sp]
+	add x19, x19, x19
+	cmp x19, #0
+	b.eq .L1
+	ldr x17, [sp]
+	ldr x19, [sp, #8]
+	add sp, sp, #0x10
+	br x17
+.L1:
+	ldr x0, [sp]
+	ldr x19, [sp, #8]
+	add sp, sp, #0x10
+	ret

--- a/tests/x86/tailcall_001.irt
+++ b/tests/x86/tailcall_001.irt
@@ -1,0 +1,24 @@
+--TEST--
+001: tailcall: epilogue does not override op2
+--TARGET--
+x86
+--ARGS--
+-S
+--CODE--
+{
+	l_1 = START(l_4);
+	uintptr_t f = PARAM(l_1, "p", 1);
+	l_2 = CALL(l_1, f);
+	l_3 = TAILCALL(l_2, f);
+	l_4 = UNREACHABLE(l_3);
+}
+--EXPECT--
+test:
+	pushl %ebx
+	subl $8, %esp
+	movl 0x10(%esp), %ebx
+	calll *%ebx
+	movl %ebx, %eax
+	addl $8, %esp
+	popl %ebx
+	jmpl *%eax

--- a/tests/x86/tailcall_002.irt
+++ b/tests/x86/tailcall_002.irt
@@ -1,0 +1,30 @@
+--TEST--
+002: tailcall: epilogue does not override op2: spill slot
+--TARGET--
+x86
+--ARGS--
+-S --debug-regset 0x00000088
+--CODE--
+# debug-regset: EBX, EDI
+{
+	l_1 = START(l_4);
+	uintptr_t f = PARAM(l_1, "p", 1);
+	uintptr_t f2 = PROTO/2(f, func(void):void __fastcall);
+	l_2 = CALL(l_1, f2);
+	l_3 = TAILCALL/1(l_2, f2, f2);
+	l_4 = UNREACHABLE(l_3);
+}
+--EXPECT--
+test:
+	pushl %ebx
+	pushl %edi
+	subl $4, %esp
+	movl 0x10(%esp), %ebx
+	calll *%ebx
+	movl %ebx, %ecx
+	movl %ebx, %eax
+	addl $4, %esp
+	popl %edi
+	popl %ebx
+	jmpl *%eax
+

--- a/tests/x86/tailcall_003.irt
+++ b/tests/x86/tailcall_003.irt
@@ -1,0 +1,20 @@
+--TEST--
+003: tailcall: epilogue does not override op2: fuse load
+--TARGET--
+x86
+--ARGS--
+-S
+--CODE--
+{
+	l_1 = START(l_30);
+	uintptr_t d_1, l_2 = RLOAD(l_1, 3);
+	uintptr_t d_2, l_3 = LOAD(l_2, d_1);
+	l_4 = TAILCALL/0(l_3, d_2);
+	l_30 = UNREACHABLE(l_4);
+}
+--EXPECT--
+test:
+	pushl %ebx
+	movl (%ebx), %eax
+	popl %ebx
+	jmpl *%eax

--- a/tests/x86/tailcall_004.irt
+++ b/tests/x86/tailcall_004.irt
@@ -1,0 +1,38 @@
+--TEST--
+004: tailcall: epilogue does not override op2: spilled non-preserved reg
+--TARGET--
+x86
+--ARGS--
+-S --debug-regset 0x00000080
+--CODE--
+# debug-regset: EDI
+func test(uintptr_t):uintptr_t __fastcall {
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	pushl %edi
+	subl $4, %esp
+	movl %ecx, %edi
+	movl %edi, (%esp)
+	addl %edi, %edi
+	testl %edi, %edi
+	je .L1
+	movl (%esp), %eax
+	addl $4, %esp
+	popl %edi
+	jmpl *%eax
+.L1:
+	movl (%esp), %eax
+	addl $4, %esp
+	popl %edi
+	retl
+

--- a/tests/x86/tailcall_005.irt
+++ b/tests/x86/tailcall_005.irt
@@ -1,0 +1,38 @@
+--TEST--
+005: tailcall: epilogue does not override op2: spilled preserved reg
+--TARGET--
+x86
+--ARGS--
+-S --debug-regset 0x00000008
+--CODE--
+# debug-regset: EBX
+func test(uintptr_t):uintptr_t __fastcall {
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	pushl %ebx
+	subl $4, %esp
+	movl %ecx, %ebx
+	movl %ebx, (%esp)
+	addl %ebx, %ebx
+	testl %ebx, %ebx
+	je .L1
+	movl (%esp), %eax
+	addl $4, %esp
+	popl %ebx
+	jmpl *%eax
+.L1:
+	movl (%esp), %eax
+	addl $4, %esp
+	popl %ebx
+	retl
+

--- a/tests/x86_64/tailcall_001.irt
+++ b/tests/x86_64/tailcall_001.irt
@@ -1,0 +1,23 @@
+--TEST--
+001: tailcall: epilogue does not override op2
+--TARGET--
+x86_64
+--ARGS--
+-S
+--CODE--
+{
+	l_1 = START(l_4);
+	uintptr_t f = PARAM(l_1, "p", 1);
+	l_2 = CALL(l_1, f);
+	l_3 = TAILCALL(l_2, f);
+	l_4 = UNREACHABLE(l_3);
+}
+--EXPECT--
+test:
+	pushq %rbx
+	movq %rdi, %rbx
+	callq *%rbx
+	movq %rbx, %rax
+	popq %rbx
+	jmpq *%rax
+

--- a/tests/x86_64/tailcall_002.irt
+++ b/tests/x86_64/tailcall_002.irt
@@ -1,0 +1,27 @@
+--TEST--
+002: tailcall: epilogue does not override op2: spill slot
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0x00000088
+--CODE--
+# debug-regset: RBX, RDI
+{
+	l_1 = START(l_4);
+	uintptr_t f = PARAM(l_1, "p", 1);
+	l_2 = CALL(l_1, f);
+	l_3 = TAILCALL/1(l_2, f, f);
+	l_4 = UNREACHABLE(l_3);
+}
+--EXPECT--
+test:
+	pushq %rbx
+	subq $0x10, %rsp
+	movq %rdi, %rbx
+	movq %rbx, (%rsp)
+	callq *%rbx
+	movq %rbx, %rdi
+	addq $0x10, %rsp
+	popq %rbx
+	jmpq *(%rsp)
+

--- a/tests/x86_64/tailcall_002.irt
+++ b/tests/x86_64/tailcall_002.irt
@@ -21,7 +21,7 @@ test:
 	movq %rbx, (%rsp)
 	callq *%rbx
 	movq %rbx, %rdi
+	movq (%rsp), %rax
 	addq $0x10, %rsp
 	popq %rbx
-	jmpq *(%rsp)
-
+	jmpq *%rax

--- a/tests/x86_64/tailcall_003.irt
+++ b/tests/x86_64/tailcall_003.irt
@@ -1,0 +1,20 @@
+--TEST--
+003: tailcall: epilogue does not override op2: fuse load
+--TARGET--
+x86_64
+--ARGS--
+-S
+--CODE--
+{
+	l_1 = START(l_30);
+	uintptr_t d_1, l_2 = RLOAD(l_1, 3);
+	uintptr_t d_2, l_3 = LOAD(l_2, d_1);
+	l_4 = TAILCALL/0(l_3, d_2);
+	l_30 = UNREACHABLE(l_4);
+}
+--EXPECT--
+test:
+	pushq %rbx
+	movq (%rbx), %rax
+	popq %rbx
+	jmpq *%rax

--- a/tests/x86_64/tailcall_004.irt
+++ b/tests/x86_64/tailcall_004.irt
@@ -1,0 +1,34 @@
+--TEST--
+004: tailcall: epilogue does not override op2: spilled non-preserved reg
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0x00000080
+--CODE--
+# debug-regset: RDI
+{
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	subq $8, %rsp
+	movq %rdi, (%rsp)
+	addq %rdi, %rdi
+	testq %rdi, %rdi
+	je .L1
+	movq (%rsp), %rax
+	addq $8, %rsp
+	jmpq *%rax
+.L1:
+	movq (%rsp), %rax
+	addq $8, %rsp
+	retq
+

--- a/tests/x86_64/tailcall_005.irt
+++ b/tests/x86_64/tailcall_005.irt
@@ -1,0 +1,38 @@
+--TEST--
+005: tailcall: epilogue does not override op2: spilled preserved reg
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0x00000008
+--CODE--
+# debug-regset: RBX
+{
+	l_1 = START(l_13);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	uintptr_t d_3 = ADD(d_2,d_2);
+	l_4 = IF(l_1, d_3);
+	l_5 = IF_TRUE(l_4);
+		uintptr_t d_1, l_6 = TAILCALL/0(l_5, d_2);
+		l_7 = UNREACHABLE(l_6);
+	l_9 = IF_FALSE(l_4);
+		l_13 = RETURN(l_9, d_2);
+}
+--EXPECT--
+test:
+	pushq %rbx
+	subq $8, %rsp
+	movq %rdi, %rbx
+	movq %rbx, (%rsp)
+	addq %rbx, %rbx
+	testq %rbx, %rbx
+	je .L1
+	movq (%rsp), %rax
+	addq $8, %rsp
+	popq %rbx
+	jmpq *%rax
+.L1:
+	movq (%rsp), %rax
+	addq $8, %rsp
+	popq %rbx
+	retq
+


### PR DESCRIPTION
TAILCALL op2 may be overridden when it is assigned to a preserved register, as the epilogue is emitted before the call:

```
{
	l_1 = START(l_4);
	uintptr_t f = PARAM(l_1, "p", 1);
	l_2 = CALL(l_1, f);
	l_3 = TAILCALL(l_2, f);
	l_4 = UNREACHABLE(l_3);
}
```

```
test:
	pushq %rbx
	movq %rdi, %rbx
	callq *%rbx
	popq %rbx
	jmpq *%rbx
```

This can not be trivially solved in RA, as the set of used preserved regs is not known yet.

Here I move op2 to a tmp reg in `ir_emit_tailcall()` when op2 is in `used_preserved_regs`.