### PR TITLE
Prevent overflow of the section buffer in dasm_put()

### DIFF
--- a/ir.h
+++ b/ir.h
@@ -1032,6 +1032,7 @@ IR_ALWAYS_INLINE void *ir_jit_compile(ir_ctx *ctx, int opt_level, size_t *size)
 #define IR_ERROR_UNSUPPORTED_CODE_RULE           3
 #define IR_ERROR_LINK                            4
 #define IR_ERROR_ENCODE                          5
+#define IR_ERROR_TOO_LARGE                       6
 
 /* IR Memmory Allocation */
 #ifndef ir_mem_malloc

--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -6162,6 +6162,14 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 	dasm_setup(&data.dasm_state, dasm_actions);
 	/* labels for each block + for each constant + rodata label + jmp_table label + for each entry + exit_table label */
 	dasm_growpc(&data.dasm_state, ctx->cfg_blocks_count + 1 + ctx->consts_count + 1 + 1 + 1 + ctx->entries_count + 1);
+	if (data.dasm_state->status != DASM_S_OK) {
+		IR_ASSERT(data.dasm_state->status == DASM_S_NOMEM);
+		dasm_free(&data.dasm_state);
+		ctx->data = NULL;
+		ctx->status = IR_ERROR_TOO_LARGE;
+		return NULL;
+	}
+
 	data.emit_constants = ir_bitset_malloc(ctx->consts_count);
 
 	if (!(ctx->flags & IR_SKIP_PROLOGUE)) {
@@ -6525,6 +6533,14 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 	if (ctx->status) {
 		dasm_free(&data.dasm_state);
 		ctx->data = NULL;
+		return NULL;
+	}
+
+	if (data.dasm_state->status != DASM_S_OK) {
+		IR_ASSERT(data.dasm_state->status == DASM_S_NOMEM);
+		dasm_free(&data.dasm_state);
+		ctx->data = NULL;
+		ctx->status = IR_ERROR_TOO_LARGE;
 		return NULL;
 	}
 

--- a/ir_emit.c
+++ b/ir_emit.c
@@ -31,9 +31,17 @@
 #define DASM_M_GROW(ctx, t, p, sz, need) \
   do { \
     size_t _sz = (sz), _need = (need); \
+    size_t _limit = sizeof(t) * DASM_SEC2POS(1); \
     if (_sz < _need) { \
+      if (_need > _limit) { \
+        Dst_REF->status = DASM_S_NOMEM; \
+        return; \
+      } \
       if (_sz < 16) _sz = 16; \
       while (_sz < _need) _sz += _sz; \
+      if (_sz > _limit) { \
+        _sz = _limit; \
+      } \
       (p) = (t *)ir_mem_realloc((p), _sz); \
       (sz) = _sz; \
     } \

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -11045,6 +11045,14 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 	dasm_setup(&data.dasm_state, dasm_actions);
 	/* labels for each block + for each constant + rodata label + jmp_table label + for each entry */
 	dasm_growpc(&data.dasm_state, ctx->cfg_blocks_count + 1 + ctx->consts_count + 1 + 1 + 1 + ctx->entries_count);
+	if (data.dasm_state->status != DASM_S_OK) {
+		IR_ASSERT(data.dasm_state->status == DASM_S_NOMEM);
+		dasm_free(&data.dasm_state);
+		ctx->data = NULL;
+		ctx->status = IR_ERROR_TOO_LARGE;
+		return NULL;
+	}
+
 	data.emit_constants = ir_bitset_malloc(ctx->consts_count);
 
 	if ((ctx->flags & IR_GEN_ENDBR) && (ctx->flags & IR_START_BR_TARGET)) {
@@ -11541,9 +11549,17 @@ next_block:;
 		return NULL;
 	}
 
+	if (data.dasm_state->status != DASM_S_OK) {
+		IR_ASSERT(data.dasm_state->status == DASM_S_NOMEM);
+		dasm_free(&data.dasm_state);
+		ctx->data = NULL;
+		ctx->status = IR_ERROR_TOO_LARGE;
+		return NULL;
+	}
+
 	ret = dasm_link(&data.dasm_state, size_ptr);
 	if (ret != DASM_S_OK) {
-		IR_ASSERT(0);
+		IR_ASSERT(ret == DASM_S_NOMEM);
 		dasm_free(&data.dasm_state);
 		ctx->data = NULL;
 		ctx->status = IR_ERROR_LINK;


### PR DESCRIPTION
When generating very large code, `dasm_put()` can increment `pos` past the maximum section size.

Sections are initialized in `dasm_setup()`: https://github.com/dstogov/ir/blob/7266a757ae8610e5a0dbc59cebc01beca29e3a4a/dynasm/dasm_x86.h#L144-L147

In a way that allows sections to have no more than `1<<24` elements: https://github.com/dstogov/ir/blob/7266a757ae8610e5a0dbc59cebc01beca29e3a4a/dynasm/dasm_x86.h#L43-L48

This causes a crash in https://github.com/php/php-src/issues/19875. At some point `pos` is incremented to a value larger than `1<<24` and written to `D->pclabels` [here](https://github.com/dstogov/ir/blob/7266a757ae8610e5a0dbc59cebc01beca29e3a4a/dynasm/dasm_x86.h#L238). Later, this position is used in `DASM_POS2PTR(D, n)`. Since `n` is larger than `1<<24`, this breaks in two ways: `DASM_POS2PTR(D, n)` unexpectedly references another section, and the offset in that section overflows the section size.

Unfortunately DynASM doesn't check that `pos` is in range. (And I don't think it's possible to estimate the required section size?)

In this PR I propose to fix this by adding checks in `DASM_M_GROW()`.

A test case can be generated with this script:

``` php
$iterations = 10_000_000;
$l_exit = 999999999;
$l = 0;
$d = 0;

printf("{\n");
printf("uint64_t c_0 = 0;\n");
printf("uint64_t c_1 = 8;\n");
printf("l_%d = START(l_%d);\n", $l_start = $l++, $l_exit);
printf("uint64_t d_%d = PARAM(l_0, \"p\", 1);\n", $d_param = $d++);
$l_merge = $l_start;
$d_addr = $d_param;
for ($i = 0; $i < $iterations; $i++) {
	printf("uint64_t d_%d, l_%d = LOAD(l_%d, d_%d);\n", $d_load = $d++, $l_load = $l++, $l_merge, $d_addr);
	printf("l_%d = IF(l_%d, d_%d);\n", $l_if = $l++, $l_load, $d_load);
	printf("l_%d = IF_TRUE(l_%d);\n", $l_if_true = $l++, $l_if);
	printf("l_%d = STORE(l_%d, d_%d, c_0);\n", $l_store = $l++, $l_if_true, $d_load);
	printf("l_%d = END(l_%d);\n", $l_end_true = $l++, $l_store);
	printf("l_%d = IF_FALSE(l_%d);\n", $l_if_false = $l++, $l_if);
	printf("l_%d = END(l_%d);\n", $l_end_false = $l++, $l_if_false);
	printf("l_%d = MERGE(l_%d, l_%d);\n", $l_merge = $l++, $l_end_true, $l_end_false);
}
printf("l_%d = RETURN(l_%d);\n", $l_exit, $l-1);
printf("}\n");
```

With `$iterations = 10_000_000`, `DASM_M_GROW()` fails in `dasm_growpc()`. With `$iterations = 1_000_000`, it fails in `dasm_put()`. (I had to comment [this code](https://github.com/dstogov/ir/blob/7266a757ae8610e5a0dbc59cebc01beca29e3a4a/ir_main.c#L1401-L1408), otherwise it fails because the buffer is too small.)