### PR TITLE
Fix crash in ir_iter_optimize_guard()

### DIFF
--- a/tests/dead_guard_001.irt
+++ b/tests/dead_guard_001.irt
@@ -1,0 +1,27 @@
+--TEST--
+001: dead guard
+--CODE--
+{
+	uintptr_t addr = 0x1000;
+	uintptr_t c_1 = 1;
+	l_0 = START(l_99);
+	uintptr_t d_0 = PARAM(l_0, "p", 1);
+	l_1 = IF(l_0, d_0);
+	l_2 = IF_TRUE(l_1);
+	l_4 = END(l_2);
+	l_5 = IF_FALSE(l_1);
+	l_6 = END(l_5);
+	l_7 = MERGE(l_4, l_6);
+	uintptr_t d_1 = PHI/2(l_7, c_1, c_1);
+	l_8 = GUARD(l_7, d_1, addr);
+	l_99 = RETURN(l_8);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_3);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	l_3 = RETURN(l_1, null);
+}

--- a/tests/dead_guard_002.irt
+++ b/tests/dead_guard_002.irt
@@ -1,0 +1,28 @@
+--TEST--
+002: dead guard with snapshot
+--CODE--
+{
+	uintptr_t addr = 0x1000;
+	uintptr_t c_1 = 1;
+	l_0 = START(l_99);
+	uintptr_t d_0 = PARAM(l_0, "p", 1);
+	l_1 = IF(l_0, d_0);
+	l_2 = IF_TRUE(l_1);
+	l_4 = END(l_2);
+	l_5 = IF_FALSE(l_1);
+	l_6 = END(l_5);
+	l_7 = MERGE(l_4, l_6);
+	uintptr_t d_1 = PHI/2(l_7, c_1, c_1);
+	l_8 = SNAPSHOT(l_7, d_0);
+	l_9 = GUARD(l_8, d_1, addr);
+	l_99 = RETURN(l_9);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_3);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	l_3 = RETURN(l_1, null);
+}


### PR DESCRIPTION
`ir_iter_optimize_guard()` considers that op3 is a snapshot ref, and calls `ir_iter_remove_insn()` on it. However, op3 is the jmp addr, which may be a const. This results in a buffer underflow when accessing `ctx->use_lists[_ref]` in `ir_iter_remove_insn()`:

<details>
  <summary>ASAN output</summary>

```
==387714==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7d73827e00e4 at pc 0x0000004db027 bp 0x7ffefb66e6c0 sp 0x7ffefb66e6b8
WRITE of size 4 at 0x7d73827e00e4 thread T0
    #0 0x0000004db026 in ir_iter_remove_insn ir_sccp.c:1175
    #1 0x000000521c75 in ir_iter_optimize_guard ir_sccp.c:3503
    #2 0x00000052762d in ir_iter_opt ir_sccp.c:3693
    #3 0x00000052844a in ir_sccp ir_sccp.c:3717
    #4 0x00000040166c in ir_compile_func ir_main.c:271
    #5 0x00000040bf66 in ir_loader_func_process ir_main.c:958
    #6 0x0000006fbb8f in parse_ir ir_load.c:1320
    #7 0x000000705333 in parse ir_load.c:2087
    #8 0x0000007057c8 in ir_load ir_load.c:2123
    #9 0x0000004128dd in main ir_main.c:1465
    #10 0x7f2383a11574 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7f2383a11627 in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x000000400a04 in _start (ir+0x400a04) (BuildId: cb344b77007681cb100868e11623c98ea1300120)

0x7d73827e00e4 is located 28 bytes before 8192-byte region [0x7d73827e0100,0x7d73827e2100)
allocated by thread T0 here:
    #0 0x7f2384ce68a3 in calloc (/lib64/libasan.so.8+0xe68a3) (BuildId: 10b8ccd49f75c21babf1d7abe51bb63589d8471f)
    #1 0x0000004518e7 in ir_build_def_use_lists ir.c:1235
    #2 0x000000401477 in ir_compile_func ir_main.c:230
    #3 0x00000040bf66 in ir_loader_func_process ir_main.c:958
    #4 0x0000006fbb8f in parse_ir ir_load.c:1320
    #5 0x000000705333 in parse ir_load.c:2087
    #6 0x0000007057c8 in ir_load ir_load.c:2123
    #7 0x0000004128dd in main ir_main.c:1465
    #8 0x7f2383a11574 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7f2383a11627 in __libc_start_main_impl ../csu/libc-start.c:360
    #10 0x000000400a04 in _start (ir+0x400a04) (BuildId: cb344b77007681cb100868e11623c98ea1300120)
```
</details>

I'm assuming that GUARD op3 used to be a SNAPSHOT, and that this code is a left over. However I wasn't able to verify that in the history, so I may be mis-interpreting it.