### PR TITLE
Fix UAF in ir_cfg_remove_dead_inputs()

### DIFF
--- a/ir_cfg.c
+++ b/ir_cfg.c
@@ -211,6 +211,7 @@ static uint32_t IR_NEVER_INLINE ir_cfg_remove_dead_inputs(ir_ctx *ctx, uint32_t 
 				if (life_inputs) {
 					ir_remove_phis_inputs(ctx, &ctx->use_lists[bb->start], insn->inputs_count, life_inputs);
 					ir_mem_free(life_inputs);
+					life_inputs = NULL;
 				}
 			}
 		}


### PR DESCRIPTION
When removing phis from the live inputs, the life_inputs is freed. However, a next iteration may again need to store life_inputs, but this is now a dangling pointer even though it should allocate a new pointer.

Related to https://github.com/php/php-src/issues/21395