### PR TITLE
Improve RLOAD/RSTORE handling

### DIFF
--- a/ir_private.h
+++ b/ir_private.h
@@ -1261,6 +1261,7 @@ struct _ir_live_range {
 #define IR_LIVE_INTERVAL_SPILL_SPECIAL   (1<<6) /* spill slot is pre-allocated in a special area (see ir_ctx.spill_reserved_base) */
 #define IR_LIVE_INTERVAL_SPILLED         (1<<7)
 #define IR_LIVE_INTERVAL_SPLIT_CHILD     (1<<8)
+#define IR_LIVE_INTERVAL_ALLOW_FIXED     (1<<9) /* allocate from fixed regs if hint is a fixed reg */
 
 struct _ir_live_interval {
 	uint8_t           type;

--- a/ir_ra.c
+++ b/ir_ra.c
@@ -761,8 +761,11 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 
 					if (reg != IR_REG_NONE) {
 						def_pos = IR_SAVE_LIVE_POS_FROM_REF(ref);
-						if (insn->op == IR_PARAM || insn->op == IR_RLOAD) {
-							/* parameter register must be kept before it's copied */
+						/* Parameter register must be kept before it's copied.
+						 * Ignore if register is fixed, as it is already
+						 * unavailable for allocation. */
+						if ((insn->op == IR_PARAM || insn->op == IR_RLOAD)
+						 && !IR_REGSET_IN(ctx->fixed_regset, reg)) {
 							ir_add_fixed_live_range(ctx, reg, IR_START_LIVE_POS_FROM_REF(bb->start), def_pos);
 						}
 					} else if (def_flags & IR_DEF_REUSES_OP1_REG) {
@@ -785,6 +788,9 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 					ival = ir_fix_live_range(ctx, v,
 						IR_START_LIVE_POS_FROM_REF(bb->start), def_pos);
 					ival->type = insn->type;
+					if (insn->op == IR_RLOAD) {
+						ival->flags |= IR_LIVE_INTERVAL_ALLOW_FIXED;
+					}
 					ir_add_use(ctx, ival, 0, def_pos, reg, def_flags, hint_ref);
 				} else {
 					/* live.remove(opd) */
@@ -798,6 +804,14 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 					ival->type = insn->type;
 					ir_add_use(ctx, ival, 0, IR_DEF_LIVE_POS_FROM_REF(ref), IR_REG_NONE, IR_USE_SHOULD_BE_IN_REG, 0);
 					continue;
+				}
+			} else if (insn->op == IR_RSTORE) {
+				ir_reg reg = constraints.def_reg;
+
+				if (reg != IR_REG_NONE) {
+					ir_add_fixed_live_range(ctx, reg,
+							IR_USE_LIVE_POS_FROM_REF(ref),
+							IR_DEF_LIVE_POS_FROM_REF(ref));
 				}
 			}
 
@@ -1380,8 +1394,11 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 
 					if (reg != IR_REG_NONE) {
 						def_pos = IR_SAVE_LIVE_POS_FROM_REF(ref);
-						if (insn->op == IR_PARAM || insn->op == IR_RLOAD) {
-							/* parameter register must be kept before it's copied */
+						/* Parameter register must be kept before it's copied.
+						 * Ignore if register is fixed, as it is already
+						 * unavailable for allocation. */
+						if ((insn->op == IR_PARAM || insn->op == IR_RLOAD)
+						 && !IR_REGSET_IN(IR_REGSET_UNION(ctx->fixed_regset, IR_REGSET_FIXED), reg)) {
 							ir_add_fixed_live_range(ctx, reg, IR_START_LIVE_POS_FROM_REF(bb->start), def_pos);
 						}
 					} else if (def_flags & IR_DEF_REUSES_OP1_REG) {
@@ -1406,6 +1423,9 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 					ival = ir_fix_live_range(ctx, v,
 						IR_START_LIVE_POS_FROM_REF(bb->start), def_pos);
 					ival->type = insn->type;
+					if (insn->op == IR_RLOAD) {
+						ival->flags |= IR_LIVE_INTERVAL_ALLOW_FIXED;
+					}
 					ir_add_use(ctx, ival, 0, def_pos, reg, def_flags, hint_ref);
 				} else {
 					/* PHIs inputs must not be processed */
@@ -1417,6 +1437,14 @@ int ir_compute_live_ranges(ir_ctx *ctx)
 					ival->type = insn->type;
 					ir_add_use(ctx, ival, 0, IR_DEF_LIVE_POS_FROM_REF(ref), IR_REG_NONE, IR_USE_SHOULD_BE_IN_REG, 0);
 					continue;
+				}
+			} else if (insn->op == IR_RSTORE) {
+				ir_reg reg = constraints.def_reg;
+
+				if (reg != IR_REG_NONE) {
+					ir_add_fixed_live_range(ctx, reg,
+							IR_USE_LIVE_POS_FROM_REF(ref),
+							IR_DEF_LIVE_POS_FROM_REF(ref));
 				}
 			}
 
@@ -2803,6 +2831,7 @@ static ir_reg ir_try_allocate_free_reg(ir_ctx *ctx, ir_live_interval *ival, ir_l
 	ir_live_pos pos, next;
 	ir_live_interval *other;
 	ir_regset available, overlapped, scratch;
+	ir_regset unavailable_fixed_regset;
 
 	if (IR_IS_TYPE_FP(ival->type)) {
 		available = IR_REGSET_FP;
@@ -2829,7 +2858,24 @@ static ir_reg ir_try_allocate_free_reg(ir_ctx *ctx, ir_live_interval *ival, ir_l
 		}
 	}
 
-	available = IR_REGSET_DIFFERENCE(available, (ir_regset)ctx->fixed_regset);
+	available = IR_REGSET_UNION(available, IR_REGSET_FIXED);
+	unavailable_fixed_regset = IR_REGSET_UNION((ir_regset)ctx->fixed_regset, IR_REGSET_FIXED);
+
+	if ((ival->flags & IR_LIVE_INTERVAL_HAS_HINT_REGS)
+	  && (ival->flags & IR_LIVE_INTERVAL_ALLOW_FIXED)) {
+		ir_use_pos *use_pos = ival->use_pos;
+		ir_reg reg;
+
+		while (use_pos) {
+			reg = use_pos->hint;
+			if (reg >= 0) {
+				IR_REGSET_EXCL(unavailable_fixed_regset, reg);
+			}
+			use_pos = use_pos->next;
+		}
+	}
+
+	available = IR_REGSET_DIFFERENCE(available, unavailable_fixed_regset);
 
 	/* for each interval it in active */
 	other = *active;

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -1691,6 +1691,7 @@ get_arg_hints:
 			flags = IR_OP2_SHOULD_BE_IN_REG;
 			break;
 		case IR_RSTORE:
+			constraints->def_reg = ctx->ir_base[ref].op3;
 			flags = IR_OP3_SHOULD_BE_IN_REG;
 			break;
 		case IR_RETURN_INT:
@@ -2844,11 +2845,6 @@ store_int:
 				return IR_STORE_FP;
 			}
 			break;
-		case IR_RLOAD:
-			if (IR_REGSET_IN(IR_REGSET_UNION((ir_regset)ctx->fixed_regset, IR_REGSET_FIXED), insn->op2)) {
-				return IR_SKIPPED | IR_RLOAD;
-			}
-			return IR_RLOAD;
 		case IR_RSTORE:
 			if (IR_IS_TYPE_INT(ctx->ir_base[insn->op2].type)) {
 				if ((ctx->flags & IR_OPT_CODEGEN)
@@ -8702,36 +8698,27 @@ static void ir_emit_rload(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 {
 	ir_reg src_reg = insn->op2;
 	ir_type type = insn->type;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
 
-	if (IR_REGSET_IN(IR_REGSET_UNION((ir_regset)ctx->fixed_regset, IR_REGSET_FIXED), src_reg)) {
-		if (ctx->vregs[def]
-		 && ctx->live_intervals[ctx->vregs[def]]
-		 && ctx->live_intervals[ctx->vregs[def]]->stack_spill_pos != -1) {
+	if (def_reg == IR_REG_NONE) {
+		/* op3 is used as a flag that the value is already stored in memory.
+		 * If op3 is set we don't have to store the value once again (in case of spilling)
+		 */
+		if (!insn->op3 || !ir_is_same_spill_slot(ctx, def, IR_MEM_BO(ctx->spill_base, insn->op3))) {
 			ir_emit_store(ctx, type, def, src_reg);
 		}
 	} else {
-		ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
-
-		if (def_reg == IR_REG_NONE) {
-			/* op3 is used as a flag that the value is already stored in memory.
-			 * If op3 is set we don't have to store the value once again (in case of spilling)
-			 */
-			if (!insn->op3 || !ir_is_same_spill_slot(ctx, def, IR_MEM_BO(ctx->spill_base, insn->op3))) {
-				ir_emit_store(ctx, type, def, src_reg);
+		if (src_reg != def_reg) {
+			if (IR_IS_TYPE_INT(type)) {
+				ir_emit_mov(ctx, type, def_reg, src_reg);
+			} else {
+				IR_ASSERT(IR_IS_TYPE_FP(type));
+				ir_emit_fp_mov(ctx, type, def_reg, src_reg);
 			}
-		} else {
-			if (src_reg != def_reg) {
-				if (IR_IS_TYPE_INT(type)) {
-					ir_emit_mov(ctx, type, def_reg, src_reg);
-				} else {
-					IR_ASSERT(IR_IS_TYPE_FP(type));
-					ir_emit_fp_mov(ctx, type, def_reg, src_reg);
-				}
-			}
-			if (IR_REG_SPILLED(ctx->regs[def][0])
-			 && (!insn->op3 || !ir_is_same_spill_slot(ctx, def,  IR_MEM_BO(ctx->spill_base, insn->op3)))) {
-				ir_emit_store(ctx, type, def, def_reg);
-			}
+		}
+		if (IR_REG_SPILLED(ctx->regs[def][0])
+		 && (!insn->op3 || !ir_is_same_spill_slot(ctx, def,  IR_MEM_BO(ctx->spill_base, insn->op3)))) {
+			ir_emit_store(ctx, type, def, def_reg);
 		}
 	}
 }

--- a/tests/bugs/gh-00132-001.irt
+++ b/tests/bugs/gh-00132-001.irt
@@ -1,0 +1,26 @@
+--TEST--
+GH-132: RLOAD/RSTORE conflict
+--TARGET--
+x86_64
+--ARGS--
+-S
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_99);
+
+    uintptr_t d_2, l_2 = RLOAD(l_1, 15);
+    l_3 = RSTORE(l_2, c_30, 15);
+    l_4 = STORE(l_3, c_35, d_2);
+
+    l_99 = RETURN(l_4);
+}
+--EXPECT--
+test:
+	movq %r15, %rax
+	movl $1, %r15d
+	movq %rax, 0xffff
+	retq

--- a/tests/bugs/gh-00132-002.irt
+++ b/tests/bugs/gh-00132-002.irt
@@ -1,0 +1,27 @@
+--TEST--
+GH-132: RLOAD/RSTORE without conflict
+--TARGET--
+x86_64
+--ARGS--
+-S
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_99);
+
+    uintptr_t d_2, l_2 = RLOAD(l_1, 15);
+    l_3 = RSTORE(l_2, c_30, 14);
+    l_4 = STORE(l_3, c_35, d_2);
+
+    l_99 = RETURN(l_4);
+}
+--EXPECT--
+test:
+	pushq %r15
+	movl $1, %r14d
+	movq %r15, 0xffff
+	popq %r15
+	retq

--- a/tests/bugs/gh-00132-003.irt
+++ b/tests/bugs/gh-00132-003.irt
@@ -1,0 +1,26 @@
+--TEST--
+GH-132: RLOAD/RSTORE conflict, fixed reg
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0xffffffffffff3fff
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_99);
+
+    uintptr_t d_2, l_2 = RLOAD(l_1, 15);
+    l_3 = RSTORE(l_2, c_30, 15);
+    l_4 = STORE(l_3, c_35, d_2);
+
+    l_99 = RETURN(l_4);
+}
+--EXPECT--
+test:
+	movq %r15, %rax
+	movl $1, %r15d
+	movq %rax, 0xffff
+	retq

--- a/tests/bugs/gh-00132-004.irt
+++ b/tests/bugs/gh-00132-004.irt
@@ -1,0 +1,25 @@
+--TEST--
+GH-132: RLOAD/RSTORE without conflict, fixed reg
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0xffffffffffff3fff
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_99);
+
+    uintptr_t d_2, l_2 = RLOAD(l_1, 15);
+    l_3 = RSTORE(l_2, c_30, 14);
+    l_4 = STORE(l_3, c_35, d_2);
+
+    l_99 = RETURN(l_4);
+}
+--EXPECT--
+test:
+	movl $1, %r14d
+	movq %r15, 0xffff
+	retq

--- a/tests/bugs/gh-00132-005.irt
+++ b/tests/bugs/gh-00132-005.irt
@@ -1,0 +1,51 @@
+--TEST--
+GH-132: RLOAD/RSTORE
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 0xffffffffffff3fff
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_364);
+
+    bool d_80, l_80 = RLOAD(l_1, 15);
+    l_81 = IF(l_80, d_80);
+    l_82 = IF_TRUE(l_81);
+    l_83 = END(l_82);
+    l_84 = IF_FALSE(l_81);
+    l_85 = END(l_84);
+    l_86 = MERGE(l_83, l_85);
+    uintptr_t d_87 = PHI(l_86, c_30, c_31);
+
+    l_92 = RSTORE(l_86, c_35, 15);
+    uintptr_t d_93, l_93 = RLOAD(l_92, 15);
+    uintptr_t d_95, l_95 = LOAD(l_93, d_93);
+    l_98 = IF(l_95, d_95);
+    l_99 = IF_TRUE(l_98, 1);
+    l_104 = IJMP(l_99, c_35);
+    l_105 = IF_FALSE(l_98);
+    l_108 = STORE(l_105, c_35, d_87);
+
+    l_363 = TAILCALL(l_108, c_35);
+    l_364 = UNREACHABLE(l_363);
+}
+--EXPECT--
+test:
+	movb %r15b, %al
+	movl $0xffff, %r15d
+	cmpq $0, (%r15)
+	jne .L1
+	movl $2, %ecx
+	testb %al, %al
+	movl $1, %eax
+	cmoveq %rcx, %rax
+	movq %rax, 0xffff
+	movq $0xffff, %rax
+	jmpq *%rax
+.L1:
+	movq $0xffff, %rax
+	jmpq *%rax

--- a/tests/bugs/gh-00132-006.irt
+++ b/tests/bugs/gh-00132-006.irt
@@ -1,0 +1,34 @@
+--TEST--
+GH-132: RLOAD/RSTORE: Spilled RLOAD
+--TARGET--
+x86_64
+--ARGS--
+-S --debug-regset 1
+--CODE--
+{
+    uintptr_t c_30 = 1;
+    uintptr_t c_31 = 2;
+    uintptr_t c_35 = 0xffff;
+
+    l_1 = START(l_99);
+
+	uintptr_t d_1, l_2 = RLOAD(l_1, 15);
+    l_3 = RSTORE(l_2, d_1, 15);
+    uintptr_t d_2, l_4 = RLOAD(l_3, 15);
+    l_5 = RSTORE(l_4, d_1, 15);
+	uintptr_t d_3 = ADD(d_2, c_35);
+    l_6 = STORE(l_5, d_3, c_31);
+
+    l_99 = RETURN(l_6);
+}
+--EXPECT--
+test:
+	subq $8, %rsp
+	movq %r15, %rax
+	movq %rax, (%rsp)
+	movq %rax, %r15
+	movq %r15, %rax
+	movq (%rsp), %r15
+	movq $2, 0xffff(%rax)
+	addq $8, %rsp
+	retq

--- a/tests/bugs/gh-00132-007.irt
+++ b/tests/bugs/gh-00132-007.irt
@@ -1,0 +1,31 @@
+--TEST--
+GH-132: RLOAD/RSTORE rsp
+--TARGET--
+x86_64
+--ARGS--
+-S
+--CODE--
+{
+	uintptr_t fn = func free(uintptr_t): void;
+	uintptr_t c_0 = 0xffff;
+
+	l_1 = START(l_99);
+
+	uintptr_t d_2, l_2 = RLOAD(l_1, 4);
+	uintptr_t d_3 = COPY(d_2, 1);
+
+	l_4 = STORE(l_2, d_3, c_0);
+
+	l_5 = CALL/1(l_4, fn, d_3);
+
+	l_99 = RETURN(l_5);
+}
+--EXPECT--
+test:
+	subq $8, %rsp
+	movq %rsp, %rdi
+	movq $0xffff, (%rdi)
+	callq free
+	addq $8, %rsp
+	retq
+


### PR DESCRIPTION
The result of `RLOAD()` may be be clobbered by an `RSTORE()` before use: GH-132.

This is an attempt to fix that:

 * Add fixed live ranges for RSTOREs
 * Allocate registers normally for RLOAD, even for loads of fixed regs, so that a copy is made in case an RSTORE conflicts with the RLOAD live range
 * Introduce IR_LIVE_INTERVAL_ALLOW_FIXED: Allows to allocate a register from the fixed_regs set, when hints match
 * Do not add a fixed live range for PARAM/RLOAD of fixed regs, as it's not necessary

Generated code in PHP JIT mostly didn't change after this.

TODO:

 * [ ] Aarch64