### PR TITLE
Fix README mandelbrot path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ git clone https://github.com/dstogov/ir.git
 cd ir
 make
 make test
-./ir bench/mandelbrit.ir --run
-./ir bench/mandelbrit.ir -S
+./ir bench/mandelbrot.ir --run
+./ir bench/mandelbrot.ir -S
 ./ir --help
 ```
 


### PR DESCRIPTION
## Summary

- Fix README commands to reference `bench/mandelbrot.ir`, matching the existing benchmark file.

## Validation

- `git diff --check HEAD~1 HEAD`
