### PR TITLE
ir: Fix shift overflow in AND(SHR, C) constant folding

### DIFF
--- a/ir_fold.h
+++ b/ir_fold.h
@@ -2924,7 +2924,7 @@ IR_FOLD(AND(SHR, C_I8))
 IR_FOLD(AND(SHR, C_U8))
 {
 	if (IR_IS_CONST_REF(op1_insn->op2)) {
-		if (((uint8_t)-1) >> ctx->ir_base[op1_insn->op2].val.u8 == op2_insn->val.u8) {
+		if (((uint8_t)-1) >> (ctx->ir_base[op1_insn->op2].val.u8 & 0x7) == op2_insn->val.u8) {
 			IR_FOLD_COPY(op1);
 		}
 	}
@@ -2935,7 +2935,7 @@ IR_FOLD(AND(SHR, C_I16))
 IR_FOLD(AND(SHR, C_U16))
 {
 	if (IR_IS_CONST_REF(op1_insn->op2)) {
-		if (((uint16_t)-1) >> ctx->ir_base[op1_insn->op2].val.u16 == op2_insn->val.u16) {
+		if (((uint16_t)-1) >> (ctx->ir_base[op1_insn->op2].val.u16 & 0xf) == op2_insn->val.u16) {
 			IR_FOLD_COPY(op1);
 		}
 	}
@@ -2946,7 +2946,7 @@ IR_FOLD(AND(SHR, C_I32))
 IR_FOLD(AND(SHR, C_U32))
 {
 	if (IR_IS_CONST_REF(op1_insn->op2)) {
-		if (((uint32_t)-1) >> ctx->ir_base[op1_insn->op2].val.u32 == op2_insn->val.u32) {
+		if (((uint32_t)-1) >> (ctx->ir_base[op1_insn->op2].val.u32 & 0x1f) == op2_insn->val.u32) {
 			IR_FOLD_COPY(op1);
 		}
 	}
@@ -2957,7 +2957,7 @@ IR_FOLD(AND(SHR, C_I64))
 IR_FOLD(AND(SHR, C_U64))
 {
 	if (IR_IS_CONST_REF(op1_insn->op2)) {
-		if (((uint64_t)-1) >> ctx->ir_base[op1_insn->op2].val.u64 == op2_insn->val.u64) {
+		if (((uint64_t)-1) >> (ctx->ir_base[op1_insn->op2].val.u64 & 0x3f) == op2_insn->val.u64) {
 			IR_FOLD_COPY(op1);
 		}
 	}

--- a/tests/folding/fold_014.irt
+++ b/tests/folding/fold_014.irt
@@ -1,0 +1,28 @@
+--TEST--
+014: FOLD: AND(SHR(X, C), MASK) redundant mask with wide shift count
+--ARGS--
+-O2 --save
+--CODE--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	uint32_t c_4 = 34;
+	uint32_t c_5 = 1073741823;
+	l_1 = START(l_7);
+	uint32_t d_2 = PARAM(l_1, "a", 1);
+	uint32_t d_3 = SHR(d_2, c_4);
+	uint32_t d_4 = AND(d_3, c_5);
+	l_7 = RETURN(l_1, d_4);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	uint32_t c_4 = 34;
+	l_1 = START(l_4);
+	uint32_t d_2 = PARAM(l_1, "a", 1);
+	uint32_t d_3 = SHR(d_2, c_4);
+	l_4 = RETURN(l_1, d_3);
+}


### PR DESCRIPTION
The redundancy rules for AND of a shifted value against a mask computed the shifted all ones value without masking the shift count, which is undefined behavior when the count reaches the type width.

Mask the shift count per type width to match the existing SHR constant folding.