### PR TITLE
Fix dead loop guard that never re-pins OVERFLOW after code motion

### DIFF
--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -595,7 +595,7 @@ static void ir_gcm_schedule_late(ir_ctx *ctx, ir_ref ref, uint32_t b)
 			ir_use_list *use_list = &ctx->use_lists[ref];
 			ir_ref n, *p, use;
 
-			for (n = use_list->count, p = &ctx->use_edges[use_list->refs]; n < 0; p++, n--) {
+			for (n = use_list->count, p = &ctx->use_edges[use_list->refs]; n > 0; p++, n--) {
 				use = *p;
 				if (ctx->ir_base[use].op == IR_OVERFLOW) {
 					ctx->cfg_map[use] = b;


### PR DESCRIPTION
The use-list scan in ir_gcm_schedule_late() that pulls an IR_OVERFLOW projection into its ADD/SUB/MUL_OV block runs `for (n = use_list->count; ...; n < 0; ...)`. n starts at a non-negative count, so the body never executes; every other use-list scan in the file uses n > 0. With the loop dead, an OV op relocated by GCM can leave its OVERFLOW projection in a different block, where it is emitted standalone (seto/setc) over already-clobbered flags. Using n > 0 restores the re-pin.