### PR TITLE
Harden debug-only paths (IR verifier, GDB JIT builder) against out-of-bounds access

### DIFF
--- a/ir_check.c
+++ b/ir_check.c
@@ -173,7 +173,7 @@ bool ir_check(const ir_ctx *ctx)
 					if (IR_OPND_KIND(flags, j) != IR_OPND_DATA) {
 						fprintf(stderr, "ir_base[%d].ops[%d] reference (%d) must not be constant\n", i, j, use);
 						ok = 0;
-					} else if (use >= ctx->consts_count) {
+					} else if (-use >= ctx->consts_count) {
 						fprintf(stderr, "ir_base[%d].ops[%d] constant reference (%d) is out of range\n", i, j, use);
 						ok = 0;
 					}
@@ -181,6 +181,7 @@ bool ir_check(const ir_ctx *ctx)
 					if (use >= ctx->insns_count) {
 						fprintf(stderr, "ir_base[%d].ops[%d] insn reference (%d) is out of range\n", i, j, use);
 						ok = 0;
+						continue;
 					}
 					use_insn = &ctx->ir_base[use];
 					switch (IR_OPND_KIND(flags, j)) {

--- a/ir_gdb.c
+++ b/ir_gdb.c
@@ -198,9 +198,12 @@ static uint32_t ir_gdbjit_strz(ir_gdbjit_ctx *ctx, const char *str)
 {
 	uint8_t *p = ctx->p;
 	uint32_t ofs = (uint32_t)(p - ctx->startp);
-	do {
-		*p++ = (uint8_t)*str;
-	} while (*str++);
+	while (*str) {
+		IR_ASSERT(p < ctx->obj.space + sizeof(ctx->obj.space));
+		*p++ = (uint8_t)*str++;
+	}
+	IR_ASSERT(p < ctx->obj.space + sizeof(ctx->obj.space));
+	*p++ = '\0';
 	ctx->p = p;
 	return ofs;
 }
@@ -209,6 +212,7 @@ static uint32_t ir_gdbjit_strz(ir_gdbjit_ctx *ctx, const char *str)
 static void ir_gdbjit_uleb128(ir_gdbjit_ctx *ctx, uint32_t v)
 {
 	uint8_t *p = ctx->p;
+	IR_ASSERT(p + 5 <= ctx->obj.space + sizeof(ctx->obj.space));
 	for (; v >= 0x80; v >>= 7)
 		*p++ = (uint8_t)((v & 0x7f) | 0x80);
 	*p++ = (uint8_t)v;
@@ -219,6 +223,7 @@ static void ir_gdbjit_uleb128(ir_gdbjit_ctx *ctx, uint32_t v)
 static void ir_gdbjit_sleb128(ir_gdbjit_ctx *ctx, int32_t v)
 {
 	uint8_t *p = ctx->p;
+	IR_ASSERT(p + 5 <= ctx->obj.space + sizeof(ctx->obj.space));
 	for (; (uint32_t)(v+0x40) >= 0x80; v >>= 7)
 		*p++ = (uint8_t)((v & 0x7f) | 0x80);
 	*p++ = (uint8_t)(v & 0x7f);
@@ -229,6 +234,7 @@ static void ir_gdbjit_secthdr(ir_gdbjit_ctx *ctx)
 {
 	ir_elf_sectheader *sect;
 
+	IR_ASSERT(ctx->p < ctx->obj.space + sizeof(ctx->obj.space));
 	*ctx->p++ = '\0';
 
 #define SECTDEF(id, tp, al)                       \
@@ -267,6 +273,7 @@ static void ir_gdbjit_symtab(ir_gdbjit_ctx *ctx)
 {
 	ir_elf_symbol *sym;
 
+	IR_ASSERT(ctx->p < ctx->obj.space + sizeof(ctx->obj.space));
 	*ctx->p++ = '\0';
 
 	sym = &ctx->obj.sym[GDBJIT_SYM_FILE];
@@ -459,6 +466,7 @@ static void ir_gdbjit_initsect(ir_gdbjit_ctx *ctx, int sect)
 static void ir_gdbjit_initsect_done(ir_gdbjit_ctx *ctx, int sect)
 {
 	ctx->obj.sect[sect].size = (uintptr_t)(ctx->p - ctx->startp);
+	IR_ASSERT(ctx->p <= ctx->obj.space + sizeof(ctx->obj.space));
 }
 
 static void ir_gdbjit_buildobj(ir_gdbjit_ctx *ctx, uint32_t sp_offset, uint32_t sp_adjustment)


### PR DESCRIPTION
Two debug-only out-of-bounds hardening fixes found while auditing the framework.

ir_check(): after flagging an out-of-range instruction operand it still dereferenced ir_base[use], an out-of-bounds read on the input it just rejected; it now skips to the next operand. The constant-operand range check compared a negative const ref against consts_count and never fired; it now tests -use against consts_count to match the insn-ref check.

The GDB JIT ELF builder (ir_gdbjit_strz/uleb128/sleb128 and raw ctx->p writes) fills a fixed space[4096] stack buffer guarded only by an IR_ASSERT on the final size, which runs after the writes and is compiled out in release, so a long symbol or file name overflowed the stack. It now asserts ctx->p stays within space[] at each write site. A runtime bound wouldn't help: with an over-long name strz fills the buffer and the next raw DU16 write in debuginfo overflows instead (those fixed-width writes can't truncate), so the bound only relocates an overflow that real names never reach.

Both paths are debug-only (IR_DEBUG verifier and GDB JIT registration) and not reachable from normal codegen. No test regressions.
