### PR TITLE
ir: Extend narrow integer constants after folding

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -1074,12 +1074,27 @@ ir_fold_copy:
 		return IR_FOLD_DO_COPY;
 	}
 ir_fold_const:
-	if (!ctx->use_lists) {
-		return ir_const(ctx, val, IR_OPT_TYPE(opt));
-	} else {
-		ctx->fold_insn.opt = IR_OPT(IR_OPT_TYPE(opt), IR_OPT_TYPE(opt));
-		ctx->fold_insn.val.u64 = val.u64;
-		return IR_FOLD_DO_CONST;
+	{
+		ir_type type = IR_OPT_TYPE(opt);
+
+		/* Extend a narrow integer result to its type width so no
+		 * fold rule sees garbage in the upper bits. */
+		if (IR_IS_TYPE_INT(type) && ir_type_size[type] < 8) {
+			uint32_t shift = (8 - ir_type_size[type]) * 8;
+			if (IR_IS_TYPE_SIGNED(type)) {
+				val.i64 = (int64_t)(val.u64 << shift) >> shift;
+			} else {
+				val.u64 = (val.u64 << shift) >> shift;
+			}
+		}
+
+		if (!ctx->use_lists) {
+			return ir_const(ctx, val, type);
+		} else {
+			ctx->fold_insn.opt = IR_OPT(type, type);
+			ctx->fold_insn.val.u64 = val.u64;
+			return IR_FOLD_DO_CONST;
+		}
 	}
 }
 

--- a/tests/folding/fold_017.irt
+++ b/tests/folding/fold_017.irt
@@ -1,0 +1,24 @@
+--TEST--
+017: FOLD: narrow MUL result canonicalized before EQ
+--ARGS--
+-O2 --save
+--CODE--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	uint8_t c_4 = 16;
+	uint8_t c_5 = 0;
+	l_1 = START(l_4);
+	uint8_t d_2 = MUL(c_4, c_4);
+	bool d_3 = EQ(d_2, c_5);
+	l_4 = RETURN(l_1, d_3);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_2);
+	l_2 = RETURN(l_1, c_3);
+}


### PR DESCRIPTION
Arithmetic fold rules compute on the narrow typed fields, so a result that overflows the type width keeps garbage in the upper bits. The folder then reads the full `val.u64` for comparison and for the divisor guards, so a value like 256 in a `U8` passes the zero check and divides by zero.

This was surfaced by the structured graph fuzzer from #160, which hit it in `DIV(C_U8, C_U8)`.

The fix canonicalizes at `ir_fold_const` so every narrow integer result is zero or sign extended to its type width, covering every fold rule at once.