### PR TITLE
ir: Guard signed integer MOD against overflow

### DIFF
--- a/ir_fold.h
+++ b/ir_fold.h
@@ -706,13 +706,44 @@ IR_FOLD(MOD(C_ADDR, C_ADDR))
 }
 
 IR_FOLD(MOD(C_I8, C_I8))
+{
+	IR_ASSERT(IR_OPT_TYPE(opt) == op1_insn->type);
+	if (op2_insn->val.i64 == 0
+	 || (op2_insn->val.i64 == -1 && op1_insn->val.i8 == INT8_MIN)) {
+		/* division by zero or signed overflow */
+		IR_FOLD_EMIT;
+	}
+	IR_FOLD_CONST_I(op1_insn->val.i8 % op2_insn->val.i8);
+}
+
 IR_FOLD(MOD(C_I16, C_I16))
+{
+	IR_ASSERT(IR_OPT_TYPE(opt) == op1_insn->type);
+	if (op2_insn->val.i64 == 0
+	 || (op2_insn->val.i64 == -1 && op1_insn->val.i16 == INT16_MIN)) {
+		/* division by zero or signed overflow */
+		IR_FOLD_EMIT;
+	}
+	IR_FOLD_CONST_I(op1_insn->val.i16 % op2_insn->val.i16);
+}
+
 IR_FOLD(MOD(C_I32, C_I32))
+{
+	IR_ASSERT(IR_OPT_TYPE(opt) == op1_insn->type);
+	if (op2_insn->val.i64 == 0
+	 || (op2_insn->val.i64 == -1 && op1_insn->val.i32 == INT32_MIN)) {
+		/* division by zero or signed overflow */
+		IR_FOLD_EMIT;
+	}
+	IR_FOLD_CONST_I(op1_insn->val.i32 % op2_insn->val.i32);
+}
+
 IR_FOLD(MOD(C_I64, C_I64))
 {
 	IR_ASSERT(IR_OPT_TYPE(opt) == op1_insn->type);
-	if (op2_insn->val.i64 == 0) {
-		/* division by zero */
+	if (op2_insn->val.i64 == 0
+	 || (op2_insn->val.i64 == -1 && op1_insn->val.i64 == INT64_MIN)) {
+		/* division by zero or signed overflow */
 		IR_FOLD_EMIT;
 	}
 	IR_FOLD_CONST_I(op1_insn->val.i64 % op2_insn->val.i64);

--- a/tests/folding/fold_018.irt
+++ b/tests/folding/fold_018.irt
@@ -1,0 +1,23 @@
+--TEST--
+018: FOLD: signed MOD INT8_MIN by minus one not folded
+--ARGS--
+-O2 --save
+--CODE--
+{
+	int8_t c_1 = -128;
+	int8_t c_2 = -1;
+	l_1 = START(l_3);
+	int8_t d_2 = MOD(c_1, c_2);
+	l_3 = RETURN(l_1, d_2);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int8_t c_4 = -128;
+	int8_t c_5 = -1;
+	l_1 = START(l_3);
+	int8_t d_2 = MOD(c_4, c_5);
+	l_3 = RETURN(l_1, d_2);
+}

--- a/tests/folding/fold_019.irt
+++ b/tests/folding/fold_019.irt
@@ -1,0 +1,23 @@
+--TEST--
+019: FOLD: signed MOD INT16_MIN by minus one not folded
+--ARGS--
+-O2 --save
+--CODE--
+{
+	int16_t c_1 = -32768;
+	int16_t c_2 = -1;
+	l_1 = START(l_3);
+	int16_t d_2 = MOD(c_1, c_2);
+	l_3 = RETURN(l_1, d_2);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int16_t c_4 = -32768;
+	int16_t c_5 = -1;
+	l_1 = START(l_3);
+	int16_t d_2 = MOD(c_4, c_5);
+	l_3 = RETURN(l_1, d_2);
+}

--- a/tests/folding/fold_020.irt
+++ b/tests/folding/fold_020.irt
@@ -1,0 +1,23 @@
+--TEST--
+020: FOLD: signed MOD INT32_MIN by minus one not folded
+--ARGS--
+-O2 --save
+--CODE--
+{
+	int32_t c_1 = -2147483648;
+	int32_t c_2 = -1;
+	l_1 = START(l_3);
+	int32_t d_2 = MOD(c_1, c_2);
+	l_3 = RETURN(l_1, d_2);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int32_t c_4 = -2147483648;
+	int32_t c_5 = -1;
+	l_1 = START(l_3);
+	int32_t d_2 = MOD(c_4, c_5);
+	l_3 = RETURN(l_1, d_2);
+}

--- a/tests/folding/fold_021.irt
+++ b/tests/folding/fold_021.irt
@@ -1,0 +1,23 @@
+--TEST--
+021: FOLD: signed MOD INT64_MIN by minus one not folded
+--ARGS--
+-O2 --save
+--CODE--
+{
+	int64_t c_1 = -9223372036854775808;
+	int64_t c_2 = -1;
+	l_1 = START(l_3);
+	int64_t d_2 = MOD(c_1, c_2);
+	l_3 = RETURN(l_1, d_2);
+}
+--EXPECT--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	int64_t c_4 = -9223372036854775808;
+	int64_t c_5 = -1;
+	l_1 = START(l_3);
+	int64_t d_2 = MOD(c_4, c_5);
+	l_3 = RETURN(l_1, d_2);
+}


### PR DESCRIPTION
The signed MOD fold guarded only a zero divisor, so `INT64_MIN % -1` fed the remainder operator an overflowing case, which is undefined. `DIV` already guards this pair, but `MOD` did not.

This was surfaced by the structured graph fuzzer from #160, which hit it in `MOD(C_I64, C_I64)`.

The fix mirrors the `DIV` guard in `MOD` and emits the node instead of folding the constant.