### PR TITLE
feat: implement REDUCE_ADD/MUL/MIN/MAX vector reduction opcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ win32/build_*
 
 fuzz/build/
 fuzz/corpus/
+libir.a

--- a/TODO
+++ b/TODO
@@ -4,7 +4,6 @@
 	- full ABI conformance
 -  MEMCPY, MEMSET
 -  Consider IR cleanup (VAR -> ALLOCA, VLOAD -> LOAD, VSTORE -> STORE, LOOP_END -> END, LOOP_BEGIN -> MERGE, PI)
--  long constants
 -  long double
 
 -  revisit ir_bind()

--- a/ir.c
+++ b/ir.c
@@ -42,7 +42,7 @@
 # include <valgrind/valgrind.h>
 #endif
 
-#define IR_TYPE_FLAGS(name, type, field, flags) ((flags)|sizeof(type)),
+#define IR_TYPE_FLAGS(name, type, field, flags) (flags),
 #define IR_TYPE_NAME(name, type, field, flags)  #name,
 #define IR_TYPE_CNAME(name, type, field, flags) #type,
 #define IR_TYPE_SIZE(name, type, field, flags)  sizeof(type),
@@ -134,6 +134,13 @@ void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted
 		}
 		return;
 	}
+
+	if (IR_IS_TYPE_VECTOR(insn->type)) {
+		// TODO: vector constants are not implemented yet ???
+		fprintf(f, "VECTOR???");
+		return;
+	}
+
 	IR_ASSERT(IR_IS_CONST_OP(insn->op) || insn->op == IR_FUNC_ADDR);
 	switch (insn->type) {
 		case IR_BOOL:
@@ -2139,9 +2146,9 @@ static ir_alias ir_check_aliasing(const ir_ctx *ctx, ir_ref addr1, ir_ref addr2,
 		} else if (offset1 == offset2) {
 			return IR_MUST_ALIAS;
 		} else if (offset1 < offset2) {
-			return offset1 + ir_type_size[type1] <= offset2 ? IR_NO_ALIAS : IR_MUST_ALIAS;
+			return offset1 + ir_get_type_size(type1) <= offset2 ? IR_NO_ALIAS : IR_MUST_ALIAS;
 		} else {
-			return offset2 + ir_type_size[type2] <= offset1 ? IR_NO_ALIAS : IR_MUST_ALIAS;
+			return offset2 + ir_get_type_size(type2) <= offset1 ? IR_NO_ALIAS : IR_MUST_ALIAS;
 		}
 	}
 
@@ -2174,11 +2181,13 @@ IR_ALWAYS_INLINE ir_ref ir_find_aliasing_load_i(const ir_ctx *ctx, ir_ref ref, i
 			if (insn->op2 == addr) {
 				if (insn->type == type) {
 					return ref; /* load forwarding (L2L) */
-				} else if (ir_type_size[insn->type] == ir_type_size[type]) {
-					return ref; /* load forwarding with bitcast (L2L) */
-				} else if (ir_type_size[insn->type] > ir_type_size[type]
-						&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(insn->type)) {
-					return ref; /* partial load forwarding (L2L) */
+				} else if (IR_IS_TYPE_SCALAR(insn->type) && IR_IS_TYPE_SCALAR(type)) {
+					if (ir_type_size[insn->type] == ir_type_size[type]) {
+						return ref; /* load forwarding with bitcast (L2L) */
+					} else if (ir_type_size[insn->type] > ir_type_size[type]
+							&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(insn->type)) {
+						return ref; /* partial load forwarding (L2L) */
+					}
 				}
 			}
 		} else if (insn->op == IR_STORE) {
@@ -2191,11 +2200,15 @@ IR_ALWAYS_INLINE ir_ref ir_find_aliasing_load_i(const ir_ctx *ctx, ir_ref ref, i
 					return IR_UNUSED;
 				} else if (type2 == type) {
 					return insn->op3; /* store forwarding (S2L) */
-				} else if (ir_type_size[type2] == ir_type_size[type]) {
-					return insn->op3; /* store forwarding with bitcast (S2L) */
-				} else if (ir_type_size[type2] > ir_type_size[type]
-						&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(type2)) {
-					return insn->op3; /* partial store forwarding (S2L) */
+				} else if (IR_IS_TYPE_SCALAR(type2) && IR_IS_TYPE_SCALAR(type)) {
+					if (ir_type_size[type2] == ir_type_size[type]) {
+						return insn->op3; /* store forwarding with bitcast (S2L) */
+					} else if (ir_type_size[type2] > ir_type_size[type]
+							&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(type2)) {
+						return insn->op3; /* partial store forwarding (S2L) */
+					} else {
+						return IR_UNUSED;
+					}
 				} else {
 					return IR_UNUSED;
 				}
@@ -2250,11 +2263,13 @@ IR_ALWAYS_INLINE ir_ref ir_find_aliasing_vload_i(const ir_ctx *ctx, ir_ref ref, 
 			if (insn->op2 == var) {
 				if (insn->type == type) {
 					return ref; /* load forwarding (L2L) */
-				} else if (ir_type_size[insn->type] == ir_type_size[type]) {
-					return ref; /* load forwarding with bitcast (L2L) */
-				} else if (ir_type_size[insn->type] > ir_type_size[type]
-						&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(insn->type)) {
-					return ref; /* partial load forwarding (L2L) */
+				} else if (IR_IS_TYPE_SCALAR(insn->type) && IR_IS_TYPE_SCALAR(type)) {
+					if (ir_type_size[insn->type] == ir_type_size[type]) {
+						return ref; /* load forwarding with bitcast (L2L) */
+					} else if (ir_type_size[insn->type] > ir_type_size[type]
+							&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(insn->type)) {
+						return ref; /* partial load forwarding (L2L) */
+					}
 				}
 			}
 		} else if (insn->op == IR_VSTORE) {
@@ -2263,11 +2278,15 @@ IR_ALWAYS_INLINE ir_ref ir_find_aliasing_vload_i(const ir_ctx *ctx, ir_ref ref, 
 			if (insn->op2 == var) {
 				if (type2 == type) {
 					return insn->op3; /* store forwarding (S2L) */
-				} else if (ir_type_size[type2] == ir_type_size[type]) {
-					return insn->op3; /* store forwarding with bitcast (S2L) */
-				} else if (ir_type_size[type2] > ir_type_size[type]
-						&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(type2)) {
-					return insn->op3; /* partial store forwarding (S2L) */
+				} else if (IR_IS_TYPE_SCALAR(type2) && IR_IS_TYPE_SCALAR(type)) {
+					if (ir_type_size[type2] == ir_type_size[type]) {
+						return insn->op3; /* store forwarding with bitcast (S2L) */
+					} else if (ir_type_size[type2] > ir_type_size[type]
+							&& IR_IS_TYPE_INT(type) && IR_IS_TYPE_INT(type2)) {
+						return insn->op3; /* partial store forwarding (S2L) */
+					} else {
+						break;
+					}
 				} else {
 					break;
 				}

--- a/ir.c
+++ b/ir.c
@@ -620,11 +620,15 @@ static IR_NEVER_INLINE void ir_const_hash_rehash(ir_ctx *ctx)
 	}
 	ctx->const_hash_mask = (ctx->const_hash_mask + 1) * 2 - 1;
 	ctx->const_hash = ir_mem_calloc(ctx->const_hash_mask + 1, sizeof(ir_ref));
-	for (ref = IR_TRUE - 1; ref > -ctx->consts_count; ref--) {
-		insn = &ctx->ir_base[ref];
-		hash = ir_const_hash(insn->val, insn->optx) & ctx->const_hash_mask;
-		insn->prev_const = ctx->const_hash[hash];
-		ctx->const_hash[hash] = ref;
+	for (ref = 1 - ctx->consts_count, insn = ctx->ir_base + ref; ref < IR_TRUE; ref++, insn++) {
+		if (insn->op == IR_LONG_CONST) {
+			ref += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+			insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+		} else {
+			hash = ir_const_hash(insn->val, insn->optx) & ctx->const_hash_mask;
+			insn->prev_const = ctx->const_hash[hash];
+			ctx->const_hash[hash] = ref;
+		}
 	}
 }
 

--- a/ir.c
+++ b/ir.c
@@ -114,10 +114,44 @@ void ir_print_escaped_str(const char *s, size_t len, FILE *f)
 	}
 }
 
-void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted)
+static void ir_print_double(double v, FILE *f)
 {
 	char buf[128];
 
+	if (isnan(v)) {
+		fprintf(f, "nan");
+	} else {
+		snprintf(buf, sizeof(buf), "%g", v);
+		if (strtod(buf, NULL) != v) {
+			snprintf(buf, sizeof(buf), "%.53e", v);
+			if (strtod(buf, NULL) != v) {
+				IR_ASSERT(0 && "can't format double");
+			}
+		}
+		fprintf(f, "%s", buf);
+	}
+}
+
+static void ir_print_float(float v, FILE *f)
+{
+	char buf[128];
+
+	if (isnan(v)) {
+		fprintf(f, "nan");
+	} else {
+		snprintf(buf, sizeof(buf), "%g", v);
+		if (strtod(buf, NULL) != v) {
+			snprintf(buf, sizeof(buf), "%.24e", v);
+			if (strtod(buf, NULL) != v) {
+				IR_ASSERT(0 && "can't format float");
+			}
+		}
+		fprintf(f, "%s", buf);
+	}
+}
+
+void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted)
+{
 	if (insn->op == IR_FUNC || insn->op == IR_SYM || insn->op == IR_LABEL) {
 		fprintf(f, "%s", ir_get_str(ctx, insn->val.name));
 		return;
@@ -136,8 +170,91 @@ void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted
 	}
 
 	if (IR_IS_TYPE_VECTOR(insn->type)) {
+		ir_type t = IR_VECTOR_BASE_TYPE(insn->type);
+		uint32_t n = IR_VECTOR_LENGTH(insn->type);
+		const void *p = insn + 1;
+
 		// TODO: vector constants are not implemented yet ???
-		fprintf(f, "VECTOR???");
+		fprintf(f, "{");
+		switch (t) {
+			case IR_I8:
+			case IR_CHAR:
+				fprintf(f, "%d", *(int8_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(int8_t);;
+					fprintf(f, ", %d", *(int8_t*)p);
+				}
+				break;
+			case IR_I16:
+				fprintf(f, "%d", *(int16_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(int16_t);
+					fprintf(f, ", %d", *(int16_t*)p);
+				}
+				break;
+			case IR_I32:
+				fprintf(f, "%d", *(int32_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(int32_t);
+					fprintf(f, ", %d", *(int32_t*)p);
+				}
+				break;
+			case IR_I64:
+				fprintf(f, "%" PRIi64, *(int64_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(int64_t);
+					fprintf(f, ", %" PRIi64, *(int64_t*)p);
+				}
+				break;
+			case IR_U8:
+				fprintf(f, "%u", *(uint8_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(uint8_t);
+					fprintf(f, ", %u", *(uint8_t*)p);
+				}
+				break;
+			case IR_U16:
+				fprintf(f, "%u", *(uint16_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(uint16_t);
+					fprintf(f, ", %u", *(uint16_t*)p);
+				}
+				break;
+			case IR_U32:
+				fprintf(f, "%u", *(uint32_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(uint32_t);
+					fprintf(f, ", %u", *(uint32_t*)p);
+				}
+				break;
+			case IR_U64:
+				fprintf(f, "%" PRIu64, *(uint64_t*)p);
+				while (--n) {
+					p = (char*)p + sizeof(uint64_t);
+					fprintf(f, ", %" PRIu64, *(uint64_t*)p);
+				}
+				break;
+			case IR_DOUBLE:
+				ir_print_double(*(double*)p, f);
+				while (--n) {
+					p = (char*)p + sizeof(double);
+					fprintf(f, ", ");
+					ir_print_double(*(double*)p, f);
+				}
+				break;
+			case IR_FLOAT:
+				ir_print_double(*(float*)p, f);
+				while (--n) {
+					p = (char*)p + sizeof(float);
+					fprintf(f, ", ");
+					ir_print_double(*(float*)p, f);
+				}
+				break;
+			default:
+				IR_ASSERT(0);
+				break;
+		}
+		fprintf(f, "}");
 		return;
 	}
 
@@ -197,32 +314,10 @@ void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted
 			fprintf(f, "%" PRIi64, insn->val.i64);
 			break;
 		case IR_DOUBLE:
-			if (isnan(insn->val.d)) {
-				fprintf(f, "nan");
-			} else {
-				snprintf(buf, sizeof(buf), "%g", insn->val.d);
-				if (strtod(buf, NULL) != insn->val.d) {
-					snprintf(buf, sizeof(buf), "%.53e", insn->val.d);
-					if (strtod(buf, NULL) != insn->val.d) {
-						IR_ASSERT(0 && "can't format double");
-					}
-				}
-				fprintf(f, "%s", buf);
-			}
+			ir_print_double(insn->val.d, f);
 			break;
 		case IR_FLOAT:
-			if (isnan(insn->val.f)) {
-				fprintf(f, "nan");
-			} else {
-				snprintf(buf, sizeof(buf), "%g", insn->val.f);
-				if (strtod(buf, NULL) != insn->val.f) {
-					snprintf(buf, sizeof(buf), "%.24e", insn->val.f);
-					if (strtod(buf, NULL) != insn->val.f) {
-						IR_ASSERT(0 && "can't format float");
-					}
-				}
-				fprintf(f, "%s", buf);
-			}
+			ir_print_float(insn->val.f, f);
 			break;
 		default:
 			IR_ASSERT(0);
@@ -710,6 +805,42 @@ ir_ref ir_const_label(ir_ctx *ctx, ir_str str)
 	ir_val val;
 	val.u64 = str;
 	return ir_const_ex(ctx, val, IR_ADDR, IR_OPTX(IR_LABEL, IR_ADDR, 0));
+}
+
+ir_ref ir_long_const(ir_ctx *ctx, ir_type type, size_t size)
+{
+	ir_ref ref = ctx->consts_count;
+	ir_insn *insn;
+
+	IR_ASSERT(size <= 0xfff0);
+
+	ref = ctx->consts_count + IR_ALIGNED_SIZE(size, sizeof(ir_insn)) / sizeof(ir_insn);
+	while (UNEXPECTED(ref >= ctx->consts_limit)) {
+		ir_grow_bottom(ctx);
+	}
+	ctx->consts_count = ref + 1;
+	ref = -ref;
+
+	insn = &ctx->ir_base[ref];
+	insn->optx = IR_OPTX(IR_LONG_CONST, type, size);
+	insn->op1 = IR_UNUSED;
+	insn->val.u64 = 0;
+
+	ctx->flags2 |= IR_HAS_LONG_CONSTANTS;
+
+	return ref;
+}
+
+void *ir_long_const_ptr(ir_ctx *ctx, ir_ref ref)
+{
+	IR_ASSERT(IR_IS_CONST_REF(ref));
+	return (void*)&ctx->ir_base[ref + 1];
+}
+
+ir_ref ir_const_vector(ir_ctx *ctx, ir_type type)
+{
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	return ir_long_const(ctx, type, IR_VECTOR_SIZE(type));
 }
 
 ir_str ir_string(ir_ctx *ctx, const char *s)

--- a/ir.c
+++ b/ir.c
@@ -174,7 +174,6 @@ void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted
 		uint32_t n = IR_VECTOR_LENGTH(insn->type);
 		const void *p = insn + 1;
 
-		// TODO: vector constants are not implemented yet ???
 		fprintf(f, "{");
 		switch (t) {
 			case IR_I8:

--- a/ir.g
+++ b/ir.g
@@ -813,7 +813,7 @@ ir_modifier(ir_parser_ctx *p):
 	}
 ;
 
-type(uint8_t *t):
+simple_type(uint8_t *t):
 	(	"bool"      {*t = IR_BOOL;}
 	|	"uint8_t"   {*t = IR_U8;}
 	|	"uint16_t"  {*t = IR_U16;}
@@ -828,6 +828,14 @@ type(uint8_t *t):
 	|	"double"    {*t = IR_DOUBLE;}
 	|	"float"     {*t = IR_FLOAT;}
 	)
+;
+
+type(uint8_t *t):
+		simple_type(t)
+	|	{ir_val val;}
+		"<" simple_type(t) "*" DECNUMBER(IR_I32, &val) ">"
+		{if (val.u64 == 0 || val.u64 > 64 || (val.u64 & (val.u64 - 1)) != 0) yy_error("unsupported vector length");}
+		{*t = ir_make_vector_type(*t, val.u32);}
 ;
 
 func(uint8_t *op):

--- a/ir.g
+++ b/ir.g
@@ -582,6 +582,8 @@ ir_insn(ir_parser_ctx *p):
 	{uint32_t flags;}
 	{uint32_t params_count;}
 	{uint8_t param_types[IR_MAX_OPERANDS + 1];}
+	{void *ptr;}
+	{ir_type t2;}
 	(
 		type(&t)
 		ID(&str, &len)
@@ -596,6 +598,41 @@ ir_insn(ir_parser_ctx *p):
 	(	{val.u64 = 0;}
 		const(t, &val)
 		{ref = ir_const(p->ctx, val, t);}
+	|	"{"
+		{ref = ir_const_vector(p->ctx, t);}
+		{ptr = ir_long_const_ptr(p->ctx, ref);}
+		{memset(ptr, 0, IR_VECTOR_SIZE(t));}
+		{t2 = IR_VECTOR_BASE_TYPE(t);}
+		(
+			const(t2, &val)
+			{
+				switch (ir_type_size[2]) {
+					case 1: *(uint8_t*)ptr  = val.u8;  ptr = (char*)ptr + 1; break;
+					case 2: *(uint16_t*)ptr = val.u16; ptr = (char*)ptr + 2; break;
+					case 4: *(uint32_t*)ptr = val.u32; ptr = (char*)ptr + 4; break;
+					case 8: *(uint64_t*)ptr = val.u64; ptr = (char*)ptr + 8; break;
+					default:
+						IR_ASSERT(0);
+						break;
+				}
+			}
+			(
+				","
+				const(t2, &val)
+				{
+					switch (ir_type_size[2]) {
+						case 1: *(uint8_t*)ptr  = val.u8;  ptr = (char*)ptr + 1; break;
+						case 2: *(uint16_t*)ptr = val.u16; ptr = (char*)ptr + 2; break;
+						case 4: *(uint32_t*)ptr = val.u32; ptr = (char*)ptr + 4; break;
+						case 8: *(uint64_t*)ptr = val.u64; ptr = (char*)ptr + 8; break;
+						default:
+							IR_ASSERT(0);
+							break;
+					}
+				}
+			)*
+		)?
+		"}"
 	|	"func"
 		(	ID(&func, &func_len)
 			{flags = 0;}

--- a/ir.h
+++ b/ir.h
@@ -180,7 +180,7 @@ typedef enum _ir_type {
 #define IR_IS_TYPE_VECTOR(t)   (((t) & IR_VECTOR_MASK) != 0)
 
 #define IR_VECTOR_BASE_TYPE(t) ((t) & IR_BASE_TYPE_MASK)
-#define IR_VECTOR_LENGTH(t)    (1 << ((((t) & IR_VECTOR_MASK) >> 4) - 1))
+#define IR_VECTOR_LENGTH(t)    (1U << ((((t) & IR_VECTOR_MASK) >> 4) - 1))
 
 #ifdef IR_64
 # define IR_SIZE_T          IR_U64

--- a/ir.h
+++ b/ir.h
@@ -123,11 +123,15 @@ extern "C" {
 # define IR_X86_I64 0
 #endif
 
-/* IR Type flags (low 4 bits are used for type size) */
-#define IR_TYPE_SIGNED     (1<<4)
-#define IR_TYPE_UNSIGNED   (1<<5)
-#define IR_TYPE_FP         (1<<6)
-#define IR_TYPE_SPECIAL    (1<<7)
+#ifndef IR_SIMD
+# define IR_SIMD 1
+#endif
+
+/* IR Type flags */
+#define IR_TYPE_SIGNED     (1<<0)
+#define IR_TYPE_UNSIGNED   (1<<1)
+#define IR_TYPE_FP         (1<<2)
+#define IR_TYPE_SPECIAL    (1<<3)
 #define IR_TYPE_BOOL       (IR_TYPE_SPECIAL|IR_TYPE_UNSIGNED)
 #define IR_TYPE_ADDR       (IR_TYPE_SPECIAL|IR_TYPE_UNSIGNED)
 #define IR_TYPE_CHAR       (IR_TYPE_SPECIAL|IR_TYPE_SIGNED)
@@ -151,15 +155,32 @@ extern "C" {
 #define IR_IS_TYPE_UNSIGNED(t) ((t) < IR_CHAR)
 #define IR_IS_TYPE_SIGNED(t)   ((t) >= IR_CHAR && (t) < IR_DOUBLE)
 #define IR_IS_TYPE_INT(t)      ((t) < IR_DOUBLE)
-#define IR_IS_TYPE_FP(t)       ((t) >= IR_DOUBLE)
+#define IR_IS_TYPE_FP(t)       ((t) >= IR_DOUBLE && (t) <= IR_FLOAT)
 
 #define IR_TYPE_ENUM(name, type, field, flags) IR_ ## name,
 
 typedef enum _ir_type {
 	IR_VOID,
 	IR_TYPES(IR_TYPE_ENUM)
-	IR_LAST_TYPE
+	IR_LAST_TYPE,
+
+	IR_BASE_TYPE_MASK = 0x0f,
+	IR_VECTOR_MASK    = 0x70,
+
+	IR_VECTOR_1       = 0x10,
+	IR_VECTOR_2       = 0x20,
+	IR_VECTOR_4       = 0x30,
+	IR_VECTOR_8       = 0x40,
+	IR_VECTOR_16      = 0x50,
+	IR_VECTOR_32      = 0x60,
+	IR_VECTOR_64      = 0x70,
 } ir_type;
+
+#define IR_IS_TYPE_SCALAR(t)   (((t) & IR_VECTOR_MASK) == 0)
+#define IR_IS_TYPE_VECTOR(t)   (((t) & IR_VECTOR_MASK) != 0)
+
+#define IR_VECTOR_BASE_TYPE(t) ((t) & IR_BASE_TYPE_MASK)
+#define IR_VECTOR_LENGTH(t)    (1 << ((((t) & IR_VECTOR_MASK) >> 4) - 1))
 
 #ifdef IR_64
 # define IR_SIZE_T          IR_U64
@@ -315,6 +336,11 @@ typedef enum _ir_type {
 	_(MIN,	        d2C,  def, def, ___) /* min(op1, op2)               */ \
 	_(MAX,	        d2C,  def, def, ___) /* max(op1, op2)               */ \
 	_(COND,	        d3,   def, def, def) /* op1 ? op2 : op3             */ \
+	\
+	/* SIMD vector ops                                                  */ \
+	_(EXTRACT,      d2,   def, def, ___) /* get element of vector       */ \
+	_(REPLACE,      d3,   def, def, def) /* set element of vector       */ \
+	_(SPLAT,        d1,   def, ___, ___) /* set all elements of vector  */ \
 	\
 	/* data-flow and miscellaneous ops                                  */ \
 	_(VADDR,        d1,   var, ___, ___) /* load address of local var   */ \

--- a/ir.h
+++ b/ir.h
@@ -360,6 +360,7 @@ typedef enum _ir_type {
 	_(SYM,          r0,   ___, ___, ___) /* constant symbol ref         */ \
 	_(LABEL,        r0,   ___, ___, ___) /* label address ref           */ \
 	_(STR,          r0,   ___, ___, ___) /* constant str ref            */ \
+	_(LONG_CONST,   r0,   ___, ___, ___) /* long constant (vector)      */ \
 	\
 	/* call ops                                                         */ \
 	_(CALL,         xN,   src, def, def) /* CALL(src, func, args...)    */ \
@@ -539,6 +540,7 @@ typedef struct _ir_insn {
 					uint16_t           inputs_count;       /* number of input control edges for MERGE, PHI, CALL, TAILCALL */
 					uint16_t           prev_insn_offset;   /* 16-bit backward offset from current instruction for CSE */
 					uint16_t           proto;
+					uint16_t           long_const_size;
 				}
 			);
 			uint32_t                   optx;
@@ -790,6 +792,10 @@ ir_ref ir_const_str(ir_ctx *ctx, ir_str str);
 ir_ref ir_const_label(ir_ctx *ctx, ir_str str);
 
 ir_ref ir_unique_const_addr(ir_ctx *ctx, uintptr_t c);
+
+ir_ref ir_long_const(ir_ctx *ctx, ir_type type, size_t size);
+void *ir_long_const_ptr(ir_ctx *ctx, ir_ref ref);
+ir_ref ir_const_vector(ir_ctx *ctx, ir_type type);
 
 void ir_print_const(const ir_ctx *ctx, const ir_insn *insn, FILE *f, bool quoted);
 

--- a/ir.h
+++ b/ir.h
@@ -343,6 +343,7 @@ typedef enum _ir_type {
 	_(SPLAT,        d1,   def, ___, ___) /* set all elements of vector  */ \
 	_(SHUFFLE,      d3,   def, def, def) /* shuffle elements of vectors */ \
 	\
+	_(REDUCE,       d1X1, def, num, ___) /* horizontal reduce; op2 = ir_op (IR_ADD/IR_MUL/IR_MIN/IR_MAX) */ \
 	/* data-flow and miscellaneous ops                                  */ \
 	_(VADDR,        d1,   var, ___, ___) /* load address of local var   */ \
 	_(FRAME_ADDR,   d0,   ___, ___, ___) /* function frame address      */ \

--- a/ir.h
+++ b/ir.h
@@ -341,6 +341,7 @@ typedef enum _ir_type {
 	_(EXTRACT,      d2,   def, def, ___) /* get element of vector       */ \
 	_(REPLACE,      d3,   def, def, def) /* set element of vector       */ \
 	_(SPLAT,        d1,   def, ___, ___) /* set all elements of vector  */ \
+	_(SHUFFLE,      d3,   def, def, def) /* shuffle elements of vectors */ \
 	\
 	/* data-flow and miscellaneous ops                                  */ \
 	_(VADDR,        d1,   var, ___, ___) /* load address of local var   */ \

--- a/ir.h
+++ b/ir.h
@@ -1009,6 +1009,7 @@ int ir_load_llvm_asm(ir_loader *loader, const char *filename);
 void ir_print_func_proto(const ir_ctx *ctx, const char *name, bool prefix, FILE *f);
 void ir_print_proto(const ir_ctx *ctx, ir_ref proto, FILE *f);
 void ir_print_proto_ex(uint8_t flags, ir_type ret_type, uint32_t params_count, const uint8_t *param_types, FILE *f);
+void ir_print_type_cname(ir_type type, FILE *f);
 void ir_save(const ir_ctx *ctx, uint32_t save_flags, FILE *f);
 
 /* IR debug dump API (implementation in ir_dump.c) */

--- a/ir_builder.h
+++ b/ir_builder.h
@@ -493,6 +493,7 @@ extern "C" {
 #define ir_REPLACE(_type, _op1, _op2, _v) ir_fold3(_ir_CTX, IR_OPT(IR_REPLACE, (_type)), (_op1), (_op2), (_v))
 #define ir_SPLAT(_type, _op1)             ir_UNARY_OP(IR_SPLAT, (_type), (_op1))
 #define ir_SHUFFLE(_type, _op1, _op2, _m) ir_fold3(_ir_CTX, IR_OPT(IR_SHUFFLE, (_type)), (_op1), (_op2), (_m))
+#define ir_REDUCE(_type, _op1, _op) ir_emit2(_ir_CTX, IR_OPT(IR_REDUCE, (_type)), (_op1), (_op))
 
 /* Unfoldable variant of COPY */
 #define ir_HARD_COPY(_type, _op1)         ir_emit2(_ir_CTX, IR_OPT(IR_COPY, (_type)), (_op1), IR_COPY_HARD)

--- a/ir_builder.h
+++ b/ir_builder.h
@@ -492,6 +492,7 @@ extern "C" {
 #define ir_EXTRACT(_type, _op1, _op2)     ir_fold2(_ir_CTX, IR_OPT(IR_EXTRACT, (_type)), (_op1), (_op2))
 #define ir_REPLACE(_type, _op1, _op2, _v) ir_fold3(_ir_CTX, IR_OPT(IR_REPLACE, (_type)), (_op1), (_op2), (_v))
 #define ir_SPLAT(_type, _op1)             ir_UNARY_OP(IR_SPLAT, (_type), (_op1))
+#define ir_SHUFFLE(_type, _op1, _op2, _m) ir_fold3(_ir_CTX, IR_OPT(IR_SHUFFLE, (_type)), (_op1), (_op2), (_m))
 
 /* Unfoldable variant of COPY */
 #define ir_HARD_COPY(_type, _op1)         ir_emit2(_ir_CTX, IR_OPT(IR_COPY, (_type)), (_op1), IR_COPY_HARD)

--- a/ir_builder.h
+++ b/ir_builder.h
@@ -489,6 +489,10 @@ extern "C" {
 /* Helper to add address with a constant offset */
 #define ir_ADD_OFFSET(_addr, _offset)     _ir_ADD_OFFSET(_ir_CTX, (_addr), (_offset))
 
+#define ir_EXTRACT(_type, _op1, _op2)     ir_fold2(_ir_CTX, IR_OPT(IR_EXTRACT, (_type)), (_op1), (_op2))
+#define ir_REPLACE(_type, _op1, _op2, _v) ir_fold3(_ir_CTX, IR_OPT(IR_REPLACE, (_type)), (_op1), (_op2), (_v))
+#define ir_SPLAT(_type, _op1)             ir_UNARY_OP(IR_SPLAT, (_type), (_op1))
+
 /* Unfoldable variant of COPY */
 #define ir_HARD_COPY(_type, _op1)         ir_emit2(_ir_CTX, IR_OPT(IR_COPY, (_type)), (_op1), IR_COPY_HARD)
 #define ir_HARD_COPY_B(_op1)              ir_HARD_COPY(IR_BOOL, _op1)

--- a/ir_check.c
+++ b/ir_check.c
@@ -238,6 +238,8 @@ bool ir_check(const ir_ctx *ctx)
 											  || insn->op == IR_SAR
 											  || insn->op == IR_ROL
 											  || insn->op == IR_ROR)
+											 && IR_IS_TYPE_INT(use_insn->type)
+											 && IR_IS_TYPE_INT(insn->type)
 											 && ir_type_size[use_insn->type] < ir_type_size[insn->type]) {
 												/* second argument of SHIFT may be incompatible with result */
 												break;
@@ -352,7 +354,7 @@ bool ir_check(const ir_ctx *ctx)
 				if (type != IR_ADDR
 				 && (!IR_IS_TYPE_INT(type) || ir_type_size[type] != ir_type_size[IR_ADDR])) {
 					fprintf(stderr, "ir_base[%d].op2 must have ADDR type (%s)\n",
-						i, ir_type_name[type]);
+						i, IR_IS_TYPE_VECTOR(type) ? "VECTOR" : ir_type_name[type]);
 					ok = 0;
 				}
 				break;

--- a/ir_dump.c
+++ b/ir_dump.c
@@ -16,6 +16,16 @@
 # error "Unknown IR target"
 #endif
 
+static void ir_dump_type_name(ir_type type, FILE *f)
+{
+	if (IR_IS_TYPE_VECTOR(type)) {
+		fprintf(f, "<%s*%d>",
+			ir_type_name[IR_VECTOR_BASE_TYPE(type)], IR_VECTOR_LENGTH(type));
+	} else {
+		fprintf(f, "%s", ir_type_name[type]);
+	}
+}
+
 void ir_dump(const ir_ctx *ctx, FILE *f)
 {
 	ir_ref i, j, n, ref, *p;
@@ -23,7 +33,9 @@ void ir_dump(const ir_ctx *ctx, FILE *f)
 	uint32_t flags;
 
 	for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
-		fprintf(f, "%05d %s %s(", i, ir_op_name[insn->op], ir_type_name[insn->type]);
+		fprintf(f, "%05d %s ", i, ir_op_name[insn->op]);
+		ir_dump_type_name(insn->type, f);
+		fprintf(f, "(");
 		ir_print_const(ctx, insn, f, true);
 		fprintf(f, ")\n");
 	}
@@ -32,7 +44,8 @@ void ir_dump(const ir_ctx *ctx, FILE *f)
 		flags = ir_op_flags[insn->op];
 		fprintf(f, "%05d %s", i, ir_op_name[insn->op]);
 		if ((flags & IR_OP_FLAG_DATA) || ((flags & IR_OP_FLAG_MEM) && insn->type != IR_VOID)) {
-			fprintf(f, " %s", ir_type_name[insn->type]);
+			fprintf(f, " ");
+			ir_dump_type_name(insn->type, f);
 		}
 		n = ir_operands_count(ctx, insn);
 		for (j = 1, p = insn->ops + 1; j <= 3; j++, p++) {
@@ -79,7 +92,9 @@ void ir_dump_dot(const ir_ctx *ctx, const char *name, const char *comments, FILE
 	fprintf(f, "\"\n");
 	fprintf(f, "\trankdir=TB;\n");
 	for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
-		fprintf(f, "\tc%d [label=\"C%d: CONST %s(", -i, -i, ir_type_name[insn->type]);
+		fprintf(f, "\tc%d [label=\"C%d: CONST ", -i, -i);
+		ir_dump_type_name(insn->type, f);
+		fprintf(f, "(");
 		/* FIXME(tony): We still cannot handle strings with escaped double quote inside */
 		ir_print_const(ctx, insn, f, false);
 		fprintf(f, ")\",style=filled,fillcolor=yellow];\n");
@@ -105,13 +120,15 @@ void ir_dump_dot(const ir_ctx *ctx, const char *name, const char *comments, FILE
 				fprintf(f, "\tn%d [label=\"%d: %s\"", i, i, ir_op_name[insn->op]);
 				fprintf(f, ",shape=diamond,style=filled,fillcolor=deepskyblue];\n");
 			} else {
+				fprintf(f, "\tn%d [label=\"%d: %s ", i, i, ir_op_name[insn->op]);
+				ir_dump_type_name(insn->type, f);
 				if (insn->op == IR_PARAM) {
-					fprintf(f, "\tn%d [label=\"%d: %s %s \\\"%s\\\"\",style=filled,fillcolor=lightblue];\n",
-						i, i, ir_op_name[insn->op], ir_type_name[insn->type], ir_get_str(ctx, insn->op2));
+					fprintf(f, " \\\"%s\\\"\",style=filled,fillcolor=lightblue];\n",
+						ir_get_str(ctx, insn->op2));
 				} else if (insn->op == IR_VAR) {
-					fprintf(f, "\tn%d [label=\"%d: %s %s \\\"%s\\\"\"];\n", i, i, ir_op_name[insn->op], ir_type_name[insn->type], ir_get_str(ctx, insn->op2));
+					fprintf(f, " \\\"%s\\\"\"];\n", ir_get_str(ctx, insn->op2));
 				} else {
-					fprintf(f, "\tn%d [label=\"%d: %s %s\",style=filled,fillcolor=deepskyblue];\n", i, i, ir_op_name[insn->op], ir_type_name[insn->type]);
+					fprintf(f, "\",style=filled,fillcolor=deepskyblue];\n");
 				}
 			}
 		}
@@ -531,7 +548,9 @@ void ir_dump_codegen(const ir_ctx *ctx, FILE *f)
 
 	fprintf(f, "{\n");
 	for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
-		fprintf(f, "\t%s c_%d = ", ir_type_cname[insn->type], i);
+		fprintf(f, "\t");
+		ir_print_type_cname(insn->type, f);
+		fprintf(f, " c_%d = ", i);
 		if (insn->op == IR_FUNC) {
 			fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
 			ir_print_proto(ctx, insn->proto, f);
@@ -606,7 +625,9 @@ void ir_dump_codegen(const ir_ctx *ctx, FILE *f)
 				if (!(flags & IR_OP_FLAG_MEM) || insn->type == IR_VOID) {
 					fprintf(f, "\tl_%d = ", i);
 				} else {
-					fprintf(f, "\t%s d_%d", ir_type_cname[insn->type], i);
+					fprintf(f, "\t");
+					ir_print_type_cname(insn->type, f);
+					fprintf(f, " d_%d", i);
 					if (ctx->vregs && ctx->vregs[i]) {
 						fprintf(f, " {R%d}", ctx->vregs[i]);
 					}
@@ -621,7 +642,8 @@ void ir_dump_codegen(const ir_ctx *ctx, FILE *f)
 			} else {
 				fprintf(f, "\t");
 				if (flags & IR_OP_FLAG_DATA) {
-					fprintf(f, "%s d_%d", ir_type_cname[insn->type], i);
+					ir_print_type_cname(insn->type, f);
+					fprintf(f, " d_%d", i);
 					if (ctx->vregs && ctx->vregs[i]) {
 						fprintf(f, " {R%d}", ctx->vregs[i]);
 					}

--- a/ir_dump.c
+++ b/ir_dump.c
@@ -555,53 +555,23 @@ void ir_dump_codegen(const ir_ctx *ctx, FILE *f)
 	bool first;
 
 	fprintf(f, "{\n");
-	/* Separate behavior to keep tests compatibility. TODO: remove the old behavior */
-	if (ctx->flags2 & IR_HAS_LONG_CONSTANTS) {
-		for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
-			fprintf(f, "\t");
-			ir_print_type_cname(insn->type, f);
-			fprintf(f, " c_%d = ", -i);
-			if (insn->op == IR_FUNC) {
-				fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
-				ir_print_proto(ctx, insn->proto, f);
-			} else if (insn->op == IR_SYM) {
-				fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
-			} else if (insn->op == IR_LABEL) {
-				fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
-			} else if (insn->op == IR_FUNC_ADDR) {
-				fprintf(f, "func *");
-				ir_print_const(ctx, insn, f, true);
-				ir_print_proto(ctx, insn->proto, f);
-			} else {
-				ir_print_const(ctx, insn, f, true);
-			}
-			fprintf(f, ";\n");
-			if (insn->op == IR_LONG_CONST) {
-				i += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
-				insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
-			}
+	for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
+		fprintf(f, "\t%s c_%d = ", ir_type_cname[insn->type], i);
+		if (insn->op == IR_FUNC) {
+			fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
+			ir_print_proto(ctx, insn->proto, f);
+		} else if (insn->op == IR_SYM) {
+			fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
+		} else if (insn->op == IR_LABEL) {
+			fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
+		} else if (insn->op == IR_FUNC_ADDR) {
+			fprintf(f, "func *");
+			ir_print_const(ctx, insn, f, true);
+			ir_print_proto(ctx, insn->proto, f);
+		} else {
+			ir_print_const(ctx, insn, f, true);
 		}
-	} else {
-		for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
-			fprintf(f, "\t");
-			ir_print_type_cname(insn->type, f);
-			fprintf(f, " c_%d = ", i);
-			if (insn->op == IR_FUNC) {
-				fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
-				ir_print_proto(ctx, insn->proto, f);
-			} else if (insn->op == IR_SYM) {
-				fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
-			} else if (insn->op == IR_LABEL) {
-				fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
-			} else if (insn->op == IR_FUNC_ADDR) {
-				fprintf(f, "func *");
-				ir_print_const(ctx, insn, f, true);
-				ir_print_proto(ctx, insn->proto, f);
-			} else {
-				ir_print_const(ctx, insn, f, true);
-			}
-			fprintf(f, ";\n");
-		}
+		fprintf(f, ";\n");
 	}
 
 	for (_b = 1; _b <= ctx->cfg_blocks_count; _b++) {

--- a/ir_dump.c
+++ b/ir_dump.c
@@ -38,6 +38,10 @@ void ir_dump(const ir_ctx *ctx, FILE *f)
 		fprintf(f, "(");
 		ir_print_const(ctx, insn, f, true);
 		fprintf(f, ")\n");
+		if (insn->op == IR_LONG_CONST) {
+			i += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+			insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+		}
 	}
 
 	for (i = IR_UNUSED + 1, insn = ctx->ir_base + i; i < ctx->insns_count; i++, insn++) {
@@ -98,6 +102,10 @@ void ir_dump_dot(const ir_ctx *ctx, const char *name, const char *comments, FILE
 		/* FIXME(tony): We still cannot handle strings with escaped double quote inside */
 		ir_print_const(ctx, insn, f, false);
 		fprintf(f, ")\",style=filled,fillcolor=yellow];\n");
+		if (insn->op == IR_LONG_CONST) {
+			i += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+			insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+		}
 	}
 
 	for (i = IR_UNUSED + 1, insn = ctx->ir_base + i; i < ctx->insns_count;) {
@@ -547,25 +555,53 @@ void ir_dump_codegen(const ir_ctx *ctx, FILE *f)
 	bool first;
 
 	fprintf(f, "{\n");
-	for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
-		fprintf(f, "\t");
-		ir_print_type_cname(insn->type, f);
-		fprintf(f, " c_%d = ", i);
-		if (insn->op == IR_FUNC) {
-			fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
-			ir_print_proto(ctx, insn->proto, f);
-		} else if (insn->op == IR_SYM) {
-			fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
-		} else if (insn->op == IR_LABEL) {
-			fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
-		} else if (insn->op == IR_FUNC_ADDR) {
-			fprintf(f, "func *");
-			ir_print_const(ctx, insn, f, true);
-			ir_print_proto(ctx, insn->proto, f);
-		} else {
-			ir_print_const(ctx, insn, f, true);
+	/* Separate behavior to keep tests compatibility. TODO: remove the old behavior */
+	if (ctx->flags2 & IR_HAS_LONG_CONSTANTS) {
+		for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
+			fprintf(f, "\t");
+			ir_print_type_cname(insn->type, f);
+			fprintf(f, " c_%d = ", -i);
+			if (insn->op == IR_FUNC) {
+				fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
+				ir_print_proto(ctx, insn->proto, f);
+			} else if (insn->op == IR_SYM) {
+				fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_LABEL) {
+				fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_FUNC_ADDR) {
+				fprintf(f, "func *");
+				ir_print_const(ctx, insn, f, true);
+				ir_print_proto(ctx, insn->proto, f);
+			} else {
+				ir_print_const(ctx, insn, f, true);
+			}
+			fprintf(f, ";\n");
+			if (insn->op == IR_LONG_CONST) {
+				i += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+				insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+			}
 		}
-		fprintf(f, ";\n");
+	} else {
+		for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
+			fprintf(f, "\t");
+			ir_print_type_cname(insn->type, f);
+			fprintf(f, " c_%d = ", i);
+			if (insn->op == IR_FUNC) {
+				fprintf(f, "func %s", ir_get_str(ctx, insn->val.name));
+				ir_print_proto(ctx, insn->proto, f);
+			} else if (insn->op == IR_SYM) {
+				fprintf(f, "sym(%s)", ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_LABEL) {
+				fprintf(f, "label(%s)", ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_FUNC_ADDR) {
+				fprintf(f, "func *");
+				ir_print_const(ctx, insn, f, true);
+				ir_print_proto(ctx, insn->proto, f);
+			} else {
+				ir_print_const(ctx, insn, f, true);
+			}
+			fprintf(f, ";\n");
+		}
 	}
 
 	for (_b = 1; _b <= ctx->cfg_blocks_count; _b++) {

--- a/ir_emit.c
+++ b/ir_emit.c
@@ -143,7 +143,7 @@ static ir_reg ir_get_param_reg(const ir_ctx *ctx, ir_ref ref)
 				}
 #endif
 			} else {
-				IR_ASSERT(IR_IS_TYPE_FP(insn->type));
+				IR_ASSERT(IR_IS_TYPE_FP(insn->type) || IR_IS_TYPE_VECTOR(insn->type));
 				if (use == ref) {
 					if (fp_param < cc->fp_param_regs_count) {
 						return cc->fp_param_regs[fp_param];
@@ -197,7 +197,7 @@ static int ir_get_args_regs(const ir_ctx *ctx, const ir_insn *insn, const ir_cal
 				regs[j] = IR_REG_NONE;
 			}
 		} else {
-			IR_ASSERT(IR_IS_TYPE_FP(type));
+			IR_ASSERT(IR_IS_TYPE_FP(type) || IR_IS_TYPE_VECTOR(type));
 			if (fp_param < cc->fp_param_regs_count) {
 				regs[j] = cc->fp_param_regs[fp_param];
 				count = j + 1;

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -669,6 +669,65 @@ static void ir_emit_replace(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 	fprintf(f, ";\n");
 }
 
+static void ir_emit_reduce(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
+{
+	ir_type src_type = ctx->ir_base[insn->op1].type;
+	uint32_t n = IR_VECTOR_LENGTH(src_type);
+	uint32_t j;
+	ir_op op = (ir_op) insn->op2;
+
+	IR_ASSERT(n > 0);
+
+	if (op == IR_ADD || op == IR_MUL) {
+		const char *sym = (op == IR_ADD) ? "+" : "*";
+
+		ir_emit_def_ref(ctx, f, def);
+		ir_emit_ref(ctx, f, insn->op1);
+		fprintf(f, "[0]");
+		for (j = 1; j < n; j++) {
+			fprintf(f, " %s ", sym);
+			ir_emit_ref(ctx, f, insn->op1);
+			fprintf(f, "[%u]", j);
+		}
+		fprintf(f, ";\n");
+	} else {
+		int is_max;
+
+		IR_ASSERT(op == IR_MIN || op == IR_MAX);
+		is_max = (op == IR_MAX);
+
+		ir_emit_def_ref(ctx, f, def);
+		ir_emit_ref(ctx, f, insn->op1);
+		fprintf(f, "[0];\n");
+		for (j = 1; j < n; j++) {
+			fprintf(f, "\td_%d = (", ctx->vregs[def]);
+			ir_emit_ref(ctx, f, insn->op1);
+			fprintf(f, "[%u] %s d_%d) ? ", j, is_max ? ">" : "<", ctx->vregs[def]);
+			ir_emit_ref(ctx, f, insn->op1);
+			fprintf(f, "[%u] : d_%d;\n", j, ctx->vregs[def]);
+		}
+	}
+}
+
+static void ir_emit_reduce_minmax(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn, int is_max)
+{
+	ir_type src_type = ctx->ir_base[insn->op1].type;
+	uint32_t n = IR_VECTOR_LENGTH(src_type);
+	uint32_t j;
+
+	IR_ASSERT(n > 0);
+	ir_emit_def_ref(ctx, f, def);
+	ir_emit_ref(ctx, f, insn->op1);
+	fprintf(f, "[0];\n");
+	for (j = 1; j < n; j++) {
+		fprintf(f, "\td_%d = (", ctx->vregs[def]);
+		ir_emit_ref(ctx, f, insn->op1);
+		fprintf(f, "[%u] %s d_%d) ? ", j, is_max ? ">" : "<", ctx->vregs[def]);
+		ir_emit_ref(ctx, f, insn->op1);
+		fprintf(f, "[%u] : d_%d;\n", j, ctx->vregs[def]);
+	}
+}
+
 static void ir_emit_splat(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
 	uint32_t n;
@@ -688,7 +747,6 @@ static void ir_emit_splat(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 	fprintf(f, "};\n");
 }
 
-<<<<<<< HEAD
 static void ir_emit_shuffle(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
 	ir_type t;
@@ -748,8 +806,6 @@ static void ir_emit_convert_vector(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 	fprintf(f, ");\n");
 }
 
-=======
->>>>>>> 51ff23a (ir_emit_c() support for vector types)
 static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn *insn)
 {
 	ir_block *bb;
@@ -973,7 +1029,10 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 			} else {
 				fprintf(f, ", ");
 			}
-			fprintf(f, "%s %s", ir_type_cname[insn->type], ir_get_str(ctx, insn->op2));
+			ir_emit_c_type_name(insn->type, f);
+			if (insn->op2) {
+				fprintf(f, " %s", ir_get_str(ctx, insn->op2));
+			}
 		}
 	}
 	if (ctx->flags & IR_VARARG_FUNC) {
@@ -1360,7 +1419,9 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 				case IR_SPLAT:
 					ir_emit_splat(ctx, f, i, insn);
 					break;
-<<<<<<< HEAD
+				case IR_REDUCE:
+					ir_emit_reduce(ctx, f, i, insn);
+					break;
 				case IR_SHUFFLE:
 					ir_emit_shuffle(ctx, f, i, insn);
 					break;
@@ -1372,8 +1433,6 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					fprintf(stderr, "ERROR: IR_%s is not implemented yet\n", ir_op_name[insn->op]);
 					exit(1);
 					return 0;
-=======
->>>>>>> 51ff23a (ir_emit_c() support for vector types)
 				default:
 					IR_ASSERT(0 && "NIY instruction");
 					ctx->status = IR_ERROR_UNSUPPORTED_CODE_RULE;

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -637,6 +637,46 @@ static void ir_emit_guard(ir_ctx *ctx, FILE *f, ir_insn *insn)
 	fprintf(f, "))();\n");
 }
 
+static void ir_emit_extract(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
+{
+	ir_emit_def_ref(ctx, f, def);
+	ir_emit_ref(ctx, f, insn->op1);
+	fprintf(f, "[");
+	ir_emit_ref(ctx, f, insn->op2);
+	fprintf(f, "];\n");
+}
+
+static void ir_emit_replace(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
+{
+	ir_emit_def_ref(ctx, f, def);
+	ir_emit_ref(ctx, f, insn->op1);
+	fprintf(f, ";\n");
+	fprintf(f, "\td_%d[", ctx->vregs[def]);
+	ir_emit_ref(ctx, f, insn->op2);
+	fprintf(f, "] = ");
+	ir_emit_ref(ctx, f, insn->op3);
+	fprintf(f, ";\n");
+}
+
+static void ir_emit_splat(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
+{
+	uint32_t n;
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(insn->type));
+	n = IR_VECTOR_LENGTH(insn->type);
+	IR_ASSERT(n > 0);
+	ir_emit_def_ref(ctx, f, def);
+	fprintf(f, "(");
+	ir_emit_c_type_name(insn->type, f);
+	fprintf(f, "){");
+	ir_emit_ref(ctx, f, insn->op1);
+	while (--n) {
+		fprintf(f, ", ");
+		ir_emit_ref(ctx, f, insn->op1);
+	}
+	fprintf(f, "};\n");
+}
+
 static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn *insn)
 {
 	ir_block *bb;
@@ -1224,6 +1264,15 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 				case IR_GUARD:
 				case IR_GUARD_NOT:
 					ir_emit_guard(ctx, f, insn);
+					break;
+				case IR_EXTRACT:
+					ir_emit_extract(ctx, f, i, insn);
+					break;
+				case IR_REPLACE:
+					ir_emit_replace(ctx, f, i, insn);
+					break;
+				case IR_SPLAT:
+					ir_emit_splat(ctx, f, i, insn);
 					break;
 				case IR_RLOAD:
 				case IR_RSTORE:

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -63,6 +63,16 @@ static void ir_emit_c_const(ir_ctx *ctx, ir_insn *insn, FILE *f)
 	}
 }
 
+static void ir_emit_c_type_name(ir_type type, FILE *f)
+{
+	if (IR_IS_TYPE_VECTOR(type)) {
+		fprintf(f, "%s __attribute__((__vector_size__(%d)))",
+			ir_type_cname[IR_VECTOR_BASE_TYPE(type)], IR_VECTOR_SIZE(type));
+	} else {
+		fprintf(f, "%s", ir_type_cname[type]);
+	}
+}
+
 static int ir_emit_dessa_move(ir_ctx *ctx, uint8_t type, ir_ref from, ir_ref to, void *data)
 {
 	FILE *f = data;
@@ -620,7 +630,9 @@ static void ir_emit_guard(ir_ctx *ctx, FILE *f, ir_insn *insn)
 	ir_emit_ref(ctx, f, insn->op2);
 	fprintf(f, ") return ");
 	// Treat guard as a function with the same return type and no arguments
-	fprintf(f, "((%s (*)(void))(", ir_type_cname[ctx->ret_type]);
+	fprintf(f, "((");
+	ir_emit_c_type_name(ctx->ret_type, f);
+	fprintf(f, " (*)(void))(");
 	ir_emit_ref(ctx, f, insn->op3);
 	fprintf(f, "))();\n");
 }
@@ -760,7 +772,9 @@ static void ir_emit_vstore(ir_ctx *ctx, FILE *f, ir_insn *insn)
 static void ir_emit_load(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
 	ir_emit_def_ref(ctx, f, def);
-	fprintf(f, "*((%s*)", ir_type_cname[insn->type]);
+	fprintf(f, "*((");
+	ir_emit_c_type_name(insn->type, f);
+	fprintf(f, "*)");
 	if (IR_IS_CONST_REF(insn->op2)) {
 		ir_emit_c_const(ctx, &ctx->ir_base[insn->op2], f);
 	} else {
@@ -773,7 +787,9 @@ static void ir_emit_store(ir_ctx *ctx, FILE *f, ir_insn *insn)
 {
 	ir_type type = ctx->ir_base[insn->op3].type;
 
-	fprintf(f, "\t*((%s*)", ir_type_cname[type]);
+	fprintf(f, "\t*((");
+	ir_emit_c_type_name(type, f);
+	fprintf(f, "*)");
 	if (IR_IS_CONST_REF(insn->op2)) {
 		ir_emit_c_const(ctx, &ctx->ir_base[insn->op2], f);
 	} else {
@@ -831,7 +847,8 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 		fprintf(f, "static ");
 	}
 	ir_emit_c_call_conv(f, ctx->flags);
-	fprintf(f, "%s %s(", ir_type_cname[ctx->ret_type != (ir_type)-1 ? ctx->ret_type : IR_VOID], name);
+	ir_emit_c_type_name(ctx->ret_type != (ir_type)-1 ? ctx->ret_type : IR_VOID, f);
+	fprintf(f, " %s(", name);
 	use_list = &ctx->use_lists[1];
 	n = use_list->count;
 	first = 1;
@@ -843,7 +860,7 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 			} else {
 				fprintf(f, ", ");
 			}
-			fprintf(f, "%s", ir_type_cname[insn->type]);
+			ir_emit_c_type_name(insn->type, f);
 			if (insn->op2) {
 				fprintf(f, " %s", ir_get_str(ctx, insn->op2));
 			}
@@ -886,13 +903,17 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 				if (!ir_bitset_in(vars, ctx->vregs[i])) {
 					ir_bitset_incl(vars, ctx->vregs[i]);
 					if (insn->op == IR_PARAM) {
-						fprintf(f, "\t%s d_%d = %s;\n", ir_type_cname[insn->type], ctx->vregs[i], ir_get_str(ctx, insn->op2));
+						fprintf(f, "\t");
+						ir_emit_c_type_name(insn->type, f);
+						fprintf(f, " d_%d = %s;\n", ctx->vregs[i], ir_get_str(ctx, insn->op2));
 					} else {
 						ir_use_list *use_list = &ctx->use_lists[i];
 
 						if (insn->op == IR_VAR) {
 							if (use_list->count > 0) {
-								fprintf(f, "\t%s %s;\n", ir_type_cname[insn->type], ir_get_str(ctx, insn->op2));
+								fprintf(f, "\t");
+								ir_emit_c_type_name(insn->type, f);
+								fprintf(f, " %s;\n", ir_get_str(ctx, insn->op2));
 							} else {
 								/* skip */
 							}
@@ -903,7 +924,9 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 						   || ctx->ir_base[ctx->use_edges[use_list->refs]].op == IR_VSTORE_v))) {
 							/* skip, we use variable name instead */
 						} else {
-							fprintf(f, "\t%s d_%d;\n", ir_type_cname[insn->type], ctx->vregs[i]);
+							fprintf(f, "\t");
+							ir_emit_c_type_name(insn->type, f);
+							fprintf(f, " d_%d;\n", ctx->vregs[i]);
 						}
 					}
 				} else if (insn->op == IR_PARAM) {
@@ -920,7 +943,9 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 	ir_mem_free(vars);
 
 	IR_BITSET_FOREACH(tmp_types, ir_bitset_len(IR_LAST_TYPE), i) {
-		fprintf(f, "\t%s tmp_%s;\n", ir_type_cname[i], ir_type_tname[i]);
+		fprintf(f, "\t");
+		ir_emit_c_type_name(i, f);
+		fprintf(f, " tmp_%s;\n", ir_type_tname[i]);
 	} IR_BITSET_FOREACH_END();
 	ir_mem_free(tmp_types);
 
@@ -1189,7 +1214,9 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					}
 					fprintf(f, "va_arg(");
 					ir_emit_ref(ctx, f, insn->op2);
-					fprintf(f, ", %s);\n", ir_type_cname[insn->type]);
+					fprintf(f, ", ");
+					ir_emit_c_type_name(insn->type, f);
+					fprintf(f, ");\n");
 					break;
 				case IR_TRAP:
 					fprintf(f, "\t__builtin_debugtrap();\n");
@@ -1246,16 +1273,18 @@ void ir_emit_c_func_decl(const char *name, uint32_t flags, ir_type ret_type, uin
 	} else if (flags & IR_STATIC) {
 		fprintf(f, "static ");
 	}
-	fprintf(f, "%s ", ir_type_cname[ret_type]);
+	ir_emit_c_type_name(ret_type, f);
+	fprintf(f, " ");
 	ir_emit_c_call_conv(f, flags);
 	fprintf(f, "%s(", name);
 	if (params_count) {
 		const uint8_t *p = param_types;
 
-		fprintf(f, "%s", ir_type_cname[*p]);
+		ir_emit_c_type_name(*p, f);
 		p++;
 		while (--params_count) {
-			fprintf(f, ", %s", ir_type_cname[*p]);
+			fprintf(f, ", ");
+			ir_emit_c_type_name(*p, f);
 			p++;
 		}
 		if (flags & IR_VARARG_FUNC) {

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -970,10 +970,7 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 			} else {
 				fprintf(f, ", ");
 			}
-			ir_emit_c_type_name(insn->type, f);
-			if (insn->op2) {
-				fprintf(f, " %s", ir_get_str(ctx, insn->op2));
-			}
+			fprintf(f, "%s %s", ir_type_cname[insn->type], ir_get_str(ctx, insn->op2));
 		}
 	}
 	if (ctx->flags & IR_VARARG_FUNC) {

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -688,6 +688,7 @@ static void ir_emit_splat(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 	fprintf(f, "};\n");
 }
 
+<<<<<<< HEAD
 static void ir_emit_shuffle(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
 	ir_type t;
@@ -747,6 +748,8 @@ static void ir_emit_convert_vector(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 	fprintf(f, ");\n");
 }
 
+=======
+>>>>>>> 51ff23a (ir_emit_c() support for vector types)
 static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn *insn)
 {
 	ir_block *bb;
@@ -1357,6 +1360,7 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 				case IR_SPLAT:
 					ir_emit_splat(ctx, f, i, insn);
 					break;
+<<<<<<< HEAD
 				case IR_SHUFFLE:
 					ir_emit_shuffle(ctx, f, i, insn);
 					break;
@@ -1368,6 +1372,8 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					fprintf(stderr, "ERROR: IR_%s is not implemented yet\n", ir_op_name[insn->op]);
 					exit(1);
 					return 0;
+=======
+>>>>>>> 51ff23a (ir_emit_c() support for vector types)
 				default:
 					IR_ASSERT(0 && "NIY instruction");
 					ctx->status = IR_ERROR_UNSUPPORTED_CODE_RULE;

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -677,6 +677,55 @@ static void ir_emit_splat(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 	fprintf(f, "};\n");
 }
 
+static void ir_emit_shuffle(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
+{
+	ir_type t;
+	uint32_t n;
+
+	t = ctx->ir_base[insn->op3].type;
+	IR_ASSERT(IR_IS_TYPE_VECTOR(t));
+	n = IR_VECTOR_LENGTH(t);
+	t = IR_VECTOR_BASE_TYPE(t);
+	IR_ASSERT(IR_IS_TYPE_INT(t));
+
+	ir_emit_def_ref(ctx, f, def);
+	fprintf(f, "__builtin_shufflevector(");
+	ir_emit_ref(ctx, f, insn->op1);
+	fprintf(f, ", ");
+	ir_emit_ref(ctx, f, insn->op2);
+
+	if (ir_type_size[t] == 1) {
+		int8_t *p = ir_long_const_ptr(ctx, insn->op3);
+
+		for (; n > 0; p++, n--) {
+			printf(", %d", (int)*p);
+		}
+	} else if (ir_type_size[t] == 2) {
+		int16_t *p = ir_long_const_ptr(ctx, insn->op3);
+
+		for (; n > 0; p++, n--) {
+			printf(", %d", (int)*p);
+		}
+	} else if (ir_type_size[t] == 4) {
+		int32_t *p = ir_long_const_ptr(ctx, insn->op3);
+
+		for (; n > 0; p++, n--) {
+			printf(", %d", (int)*p);
+		}
+	} else if (ir_type_size[t] == 8) {
+		int64_t *p = ir_long_const_ptr(ctx, insn->op3);
+
+		for (; n > 0; p++, n--) {
+			printf(", %d", (int)*p);
+		}
+	} else {
+		IR_ASSERT(0);
+	}
+
+
+	fprintf(f, ");\n");
+}
+
 static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn *insn)
 {
 	ir_block *bb;
@@ -1273,6 +1322,9 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					break;
 				case IR_SPLAT:
 					ir_emit_splat(ctx, f, i, insn);
+					break;
+				case IR_SHUFFLE:
+					ir_emit_shuffle(ctx, f, i, insn);
 					break;
 				case IR_RLOAD:
 				case IR_RSTORE:

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -155,7 +155,7 @@ static void ir_emit_binary_op(ir_ctx *ctx, FILE *f, int def, ir_insn *insn, cons
 
 static void ir_emit_signed_cast(FILE *f, ir_type type)
 {
-	if (!IR_IS_TYPE_SIGNED(type)) {
+	if (!IR_IS_TYPE_SIGNED(type) && !IR_IS_TYPE_VECTOR(type)) {
 		switch (ir_type_size[type]) {
 			default:
 				IR_ASSERT(0);
@@ -177,7 +177,7 @@ static void ir_emit_signed_cast(FILE *f, ir_type type)
 
 static void ir_emit_unsigned_cast(FILE *f, ir_type type)
 {
-	if (!IR_IS_TYPE_UNSIGNED(type)) {
+	if (!IR_IS_TYPE_UNSIGNED(type) && !IR_IS_TYPE_VECTOR(type)) {
 		switch (ir_type_size[type]) {
 			default:
 				IR_ASSERT(0);
@@ -265,6 +265,7 @@ static void ir_emit_rol_ror(ir_ctx *ctx, FILE *f, int def, ir_insn *insn, const 
 {
 	uint8_t t1 = ctx->ir_base[insn->op1].type;
 
+	IR_ASSERT(!IR_IS_TYPE_VECTOR(insn->type) && !IR_IS_TYPE_VECTOR(t1));
 	ir_emit_def_ref(ctx, f, def);
 	fprintf(f, "(");
 	ir_emit_unsigned_cast(f, t1);
@@ -286,6 +287,7 @@ static void ir_emit_bswap(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 {
 	ir_emit_def_ref(ctx, f, def);
 
+	IR_ASSERT(!IR_IS_TYPE_VECTOR(insn->type));
 	switch (ir_type_size[insn->type]) {
 		default:
 			IR_ASSERT(0);
@@ -303,6 +305,7 @@ static void ir_emit_bswap(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 
 static void ir_emit_count(ir_ctx *ctx, FILE *f, int def, ir_insn *insn, const char *name)
 {
+	IR_ASSERT(!IR_IS_TYPE_VECTOR(insn->type));
 	ir_emit_def_ref(ctx, f, def);
 	fprintf(f, "__builtin_%s%s(", name, ir_type_size[insn->type] == 8 ? "ll" : "");
 	ir_emit_ref(ctx, f, insn->op1);
@@ -437,8 +440,15 @@ static void ir_emit_trunc(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 
 static void ir_emit_bitcast(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
 {
-	IR_ASSERT(ir_type_size[insn->type] == ir_type_size[ctx->ir_base[insn->op1].type]);
-	if (IR_IS_TYPE_INT(insn->type)) {
+	IR_ASSERT(ir_get_type_size(insn->type) == ir_get_type_size(ctx->ir_base[insn->op1].type));
+	if (IR_IS_TYPE_VECTOR(insn->type) || IR_IS_TYPE_VECTOR(ctx->ir_base[insn->op1].type)) {
+		ir_emit_def_ref(ctx, f, def);
+		fprintf(f, "(");
+		ir_emit_c_type_name(insn->type, f);
+		fprintf(f, ")");
+		ir_emit_ref(ctx, f, insn->op1);
+		fprintf(f, ";\n");
+	} else if (IR_IS_TYPE_INT(insn->type)) {
 		if (IR_IS_TYPE_INT(ctx->ir_base[insn->op1].type)) {
 			ir_emit_def_ref(ctx, f, def);
 			ir_emit_ref(ctx, f, insn->op1);
@@ -557,6 +567,7 @@ static void ir_emit_overflow_math(ir_ctx *ctx, FILE *f, int def, ir_insn *insn, 
 	}
 	IR_ASSERT(overflow != IR_UNUSED);
 
+	IR_ASSERT(IR_IS_TYPE_INT(type));
 	if (ir_type_size[type] == 4 || ir_type_size[type] == 8) {
 		fprintf(f, "\tint overflow_%d;\n", overflow);
 		ir_emit_def_ref(ctx, f, def);
@@ -723,6 +734,16 @@ static void ir_emit_shuffle(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 	}
 
 
+	fprintf(f, ");\n");
+}
+
+static void ir_emit_convert_vector(ir_ctx *ctx, FILE *f, int def, ir_insn *insn)
+{
+	ir_emit_def_ref(ctx, f, def);
+	fprintf(f, "__builtin_convertvector(");
+	ir_emit_ref(ctx, f, insn->op1);
+	fprintf(f, ", ");
+	ir_emit_c_type_name(insn->type, f);
 	fprintf(f, ");\n");
 }
 
@@ -1181,13 +1202,25 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					ir_emit_count(ctx, f, i, insn, "ctz");
 					break;
 				case IR_SEXT:
-					ir_emit_sext(ctx, f, i, insn);
+					if (IR_IS_TYPE_VECTOR(insn->type)) {
+						ir_emit_convert_vector(ctx, f, i, insn);
+					} else {
+						ir_emit_sext(ctx, f, i, insn);
+					}
 					break;
 				case IR_ZEXT:
-					ir_emit_zext(ctx, f, i, insn);
+					if (IR_IS_TYPE_VECTOR(insn->type)) {
+						ir_emit_convert_vector(ctx, f, i, insn);
+					} else {
+						ir_emit_zext(ctx, f, i, insn);
+					}
 					break;
 				case IR_TRUNC:
-					ir_emit_trunc(ctx, f, i, insn);
+					if (IR_IS_TYPE_VECTOR(insn->type)) {
+						ir_emit_convert_vector(ctx, f, i, insn);
+					} else {
+						ir_emit_trunc(ctx, f, i, insn);
+					}
 					break;
 				case IR_BITCAST:
 				case IR_PROTO:
@@ -1196,7 +1229,11 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 				case IR_INT2FP:
 				case IR_FP2INT:
 				case IR_FP2FP:
-					ir_emit_conv(ctx, f, i, insn);
+					if (IR_IS_TYPE_VECTOR(insn->type)) {
+						ir_emit_convert_vector(ctx, f, i, insn);
+					} else {
+						ir_emit_conv(ctx, f, i, insn);
+					}
 					break;
 				case IR_ADD_OV:
 					ir_emit_overflow_math(ctx, f, i, insn, "add", "+");

--- a/ir_emit_llvm.c
+++ b/ir_emit_llvm.c
@@ -1303,7 +1303,7 @@ static int ir_emit_func(ir_ctx *ctx, const char *name, FILE *f)
 					ir_emit_def_ref(ctx, f, i);
 					fprintf(f, "va_arg ptr ");
 					ir_emit_ref(ctx, f, insn->op2);
-					fprintf(f, ", %s\n", ir_type_cname[insn->type]);
+					fprintf(f, ", %s\n", ir_type_llvm_name[insn->type]);
 					break;
 				case IR_TRAP:
 					ir_bitset_incl(used_intrinsics, IR_LLVM_INTR_DEBUGTRAP);

--- a/ir_fold.h
+++ b/ir_fold.h
@@ -1471,6 +1471,10 @@ IR_FOLD(BITCAST(C_BOOL))
 IR_FOLD(BITCAST(C_CHAR))
 IR_FOLD(BITCAST(C_ADDR))
 {
+	if (IR_IS_TYPE_VECTOR(IR_OPT_TYPE(opt))) {
+		// TODO: constant folding for vectors ???
+		IR_FOLD_NEXT;
+	}
 	IR_ASSERT(ir_type_size[IR_OPT_TYPE(opt)] == ir_type_size[op1_insn->type]);
 	switch (IR_OPT_TYPE(opt)) {
 		default:

--- a/ir_fold.h
+++ b/ir_fold.h
@@ -1604,6 +1604,218 @@ IR_FOLD(FP2FP(C_DOUBLE))
 	}
 }
 
+IR_FOLD(SPLAT(C_I8))
+IR_FOLD(SPLAT(C_U8))
+IR_FOLD(SPLAT(C_CHAR))
+{
+	uint8_t v = op1_insn->val.u8;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	uint8_t *ptr = (uint8_t*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(SPLAT(C_I16))
+IR_FOLD(SPLAT(C_U16))
+{
+	uint16_t v = op1_insn->val.u16;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	uint16_t *ptr = (uint16_t*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(SPLAT(C_I32))
+IR_FOLD(SPLAT(C_U32))
+{
+	uint32_t v = op1_insn->val.u32;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	uint32_t *ptr = (uint32_t*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(SPLAT(C_I64))
+IR_FOLD(SPLAT(C_U64))
+{
+	uint64_t v = op1_insn->val.u64;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	uint64_t *ptr = (uint64_t*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(SPLAT(C_FLOAT))
+{
+	float v = op1_insn->val.f;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	float *ptr = (float*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(SPLAT(C_DOUBLE))
+{
+	double v = op1_insn->val.d;
+	ir_type type = IR_OPT_TYPE(opt);
+	int n = IR_VECTOR_LENGTH(type);
+	ir_ref vec = ir_const_vector(ctx, type);
+	double *ptr = (double*)ir_long_const_ptr(ctx, vec);
+
+	for (;n > 0; ptr++, n--) {
+		*ptr = v;
+	}
+	IR_FOLD_COPY(vec);
+}
+
+IR_FOLD(REPLACE(LONG_CONST, _))
+{
+	if (IR_IS_CONST_REF(op3)
+	 && IR_IS_CONST_REF(op2)
+	 && IR_IS_TYPE_INT(op2_insn->type)
+	 && op2_insn->val.i64 >= 0
+	 && op2_insn->val.i64 < IR_VECTOR_LENGTH(op1_insn->type)) {
+		IR_ASSERT(IR_IS_TYPE_VECTOR(op1_insn->type) && IR_VECTOR_BASE_TYPE(op1_insn->type) == op3_insn->type);
+		uint32_t idx = op2_insn->val.u32;
+
+		if (op3_insn->type == IR_U8 || op3_insn->type == IR_I8 || op3_insn->type == IR_CHAR) {
+			uint8_t v = op3_insn->val.u8;
+			uint8_t *src = (uint8_t*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				uint8_t *src = (uint8_t*)ir_long_const_ptr(ctx, op1);
+				uint8_t *dst = (uint8_t*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		} else if (op3_insn->type == IR_U16 || op3_insn->type == IR_I16) {
+			uint16_t v = op3_insn->val.u16;
+			uint16_t *src = (uint16_t*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				uint16_t *src = (uint16_t*)ir_long_const_ptr(ctx, op1);
+				uint16_t *dst = (uint16_t*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		} else if (op3_insn->type == IR_U32 || op3_insn->type == IR_I32) {
+			uint32_t v = op3_insn->val.u32;
+			uint32_t *src = (uint32_t*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				uint32_t *src = (uint32_t*)ir_long_const_ptr(ctx, op1);
+				uint32_t *dst = (uint32_t*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		} else if (op3_insn->type == IR_U64 || op3_insn->type == IR_I64) {
+			uint64_t v = op3_insn->val.u64;
+			uint64_t *src = (uint64_t*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				uint64_t *src = (uint64_t*)ir_long_const_ptr(ctx, op1);
+				uint64_t *dst = (uint64_t*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		} else if (op3_insn->type == IR_DOUBLE) {
+			double v = op3_insn->val.d;
+			double *src = (double*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				double *src = (double*)ir_long_const_ptr(ctx, op1);
+				double *dst = (double*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		} else if (op3_insn->type == IR_FLOAT) {
+			float v = op3_insn->val.d;
+			float *src = (float*)ir_long_const_ptr(ctx, op1);
+			if (src[idx] == v) {
+				IR_FOLD_COPY(op1);
+			} else {
+				ir_ref vec = ir_const_vector(ctx, IR_OPT_TYPE(opt));
+				float *src = (float*)ir_long_const_ptr(ctx, op1);
+				float *dst = (float*)ir_long_const_ptr(ctx, vec);
+				memcpy(dst, src, IR_VECTOR_SIZE(IR_OPT_TYPE(opt)));
+				dst[idx] = v;
+				IR_FOLD_COPY(vec);
+			}
+		}
+	}
+	IR_FOLD_EMIT;
+}
+
+IR_FOLD(EXTRACT(LONG_CONST, _))
+{
+	if (IR_IS_CONST_REF(op2)
+	 && IR_IS_TYPE_INT(op2_insn->type)
+	 && op2_insn->val.i64 >= 0
+	 && op2_insn->val.i64 < IR_VECTOR_LENGTH(op1_insn->type)) {
+		uint32_t idx = op2_insn->val.u32;
+		void *ptr;
+
+		IR_ASSERT(IR_IS_TYPE_VECTOR(op1_insn->type) && IR_VECTOR_BASE_TYPE(op1_insn->type) == IR_OPT_TYPE(opt));
+		ptr = (uint8_t*)ir_long_const_ptr(ctx, op1);
+		switch (IR_OPT_TYPE(opt)) {
+			case IR_CHAR:
+			case IR_I8:     IR_FOLD_CONST_I(((int8_t*)ptr)[idx]);
+			case IR_I16:    IR_FOLD_CONST_I(((int16_t*)ptr)[idx]);
+			case IR_I32:    IR_FOLD_CONST_I(((int32_t*)ptr)[idx]);
+			case IR_I64:    IR_FOLD_CONST_I(((int64_t*)ptr)[idx]);
+			case IR_U8:     IR_FOLD_CONST_U(((uint8_t*)ptr)[idx]);
+			case IR_U16:    IR_FOLD_CONST_U(((uint16_t*)ptr)[idx]);
+			case IR_U32:    IR_FOLD_CONST_U(((uint32_t*)ptr)[idx]);
+			case IR_U64:    IR_FOLD_CONST_U(((uint64_t*)ptr)[idx]);
+			case IR_DOUBLE: IR_FOLD_CONST_D(((double*)ptr)[idx]);
+			case IR_FLOAT:  IR_FOLD_CONST_F(((float*)ptr)[idx]);
+			default:
+				IR_ASSERT(0);
+		}
+	}
+	IR_FOLD_EMIT;
+}
+
 // TODO: constant functions (e.g.  sin, cos)
 
 /* Copy Propagation */

--- a/ir_fold.h
+++ b/ir_fold.h
@@ -1535,15 +1535,8 @@ IR_FOLD(BITCAST(LONG_CONST))
 		if (size == IR_VECTOR_SIZE(dst_type)) {
 			ir_ref vec = ir_const_vector(ctx, dst_type);
 			void *dst = ir_long_const_ptr(ctx, vec);
-			op1_insn = &ctx->ir_base[op1];
-			switch (ir_type_size[op1_insn->type]) {
-				case 8: memcpy(dst, &op1_insn->val.u64, 8); break;
-				case 4: memcpy(dst, &op1_insn->val.u32, 4); break;
-				case 2: memcpy(dst, &op1_insn->val.u16, 2); break;
-				case 1: memcpy(dst, &op1_insn->val.u8, 1);  break;
-				default:
-					IR_ASSERT(0);
-			}
+			void *src = ir_long_const_ptr(ctx, op1);
+			memcpy(dst, src, size);
 			IR_FOLD_COPY(vec);
 		}
 	} else {

--- a/ir_fold.h
+++ b/ir_fold.h
@@ -1471,12 +1471,29 @@ IR_FOLD(BITCAST(C_BOOL))
 IR_FOLD(BITCAST(C_CHAR))
 IR_FOLD(BITCAST(C_ADDR))
 {
-	if (IR_IS_TYPE_VECTOR(IR_OPT_TYPE(opt))) {
-		// TODO: constant folding for vectors ???
+	ir_type dst_type = IR_OPT_TYPE(opt);
+
+	if (IR_IS_TYPE_VECTOR(dst_type)) {
+		uint32_t size = IR_VECTOR_SIZE(dst_type);
+
+		if (size == ir_get_type_size(op1_insn->type)) {
+			ir_ref vec = ir_const_vector(ctx, dst_type);
+			void *dst = ir_long_const_ptr(ctx, vec);
+			op1_insn = &ctx->ir_base[op1];
+			switch (ir_type_size[op1_insn->type]) {
+				case 8: memcpy(dst, &op1_insn->val.u64, 8); break;
+				case 4: memcpy(dst, &op1_insn->val.u32, 4); break;
+				case 2: memcpy(dst, &op1_insn->val.u16, 2); break;
+				case 1: memcpy(dst, &op1_insn->val.u8, 1);  break;
+				default:
+					IR_ASSERT(0);
+			}
+			IR_FOLD_COPY(vec);
+		}
 		IR_FOLD_NEXT;
 	}
-	IR_ASSERT(ir_type_size[IR_OPT_TYPE(opt)] == ir_type_size[op1_insn->type]);
-	switch (IR_OPT_TYPE(opt)) {
+	IR_ASSERT(ir_type_size[dst_type] == ir_type_size[op1_insn->type]);
+	switch (dst_type) {
 		default:
 			IR_ASSERT(0);
 		case IR_BOOL:
@@ -1506,6 +1523,51 @@ IR_FOLD(BITCAST(C_ADDR))
 		case IR_ADDR:
 			IR_FOLD_CONST_U(op1_insn->val.addr);
 	}
+}
+
+IR_FOLD(BITCAST(LONG_CONST))
+{
+	ir_type dst_type = IR_OPT_TYPE(opt);
+	ir_type src_type = op1_insn->type;
+	uint32_t size = IR_VECTOR_SIZE(src_type);
+
+	if (IR_IS_TYPE_VECTOR(dst_type)) {
+		if (size == IR_VECTOR_SIZE(dst_type)) {
+			ir_ref vec = ir_const_vector(ctx, dst_type);
+			void *dst = ir_long_const_ptr(ctx, vec);
+			op1_insn = &ctx->ir_base[op1];
+			switch (ir_type_size[op1_insn->type]) {
+				case 8: memcpy(dst, &op1_insn->val.u64, 8); break;
+				case 4: memcpy(dst, &op1_insn->val.u32, 4); break;
+				case 2: memcpy(dst, &op1_insn->val.u16, 2); break;
+				case 1: memcpy(dst, &op1_insn->val.u8, 1);  break;
+				default:
+					IR_ASSERT(0);
+			}
+			IR_FOLD_COPY(vec);
+		}
+	} else {
+		if (size == ir_type_size[dst_type]) {
+			void *ptr = ir_long_const_ptr(ctx, op1);
+
+			switch (dst_type) {
+				case IR_CHAR:
+				case IR_I8:     IR_FOLD_CONST_I(*(int8_t*)ptr);
+				case IR_I16:    IR_FOLD_CONST_I(*(int16_t*)ptr);
+				case IR_I32:    IR_FOLD_CONST_I(*(int32_t*)ptr);
+				case IR_I64:    IR_FOLD_CONST_I(*(int64_t*)ptr);
+				case IR_U8:     IR_FOLD_CONST_U(*(uint8_t*)ptr);
+				case IR_U16:    IR_FOLD_CONST_U(*(uint16_t*)ptr);
+				case IR_U32:    IR_FOLD_CONST_U(*(uint32_t*)ptr);
+				case IR_U64:    IR_FOLD_CONST_U(*(uint64_t*)ptr);
+				case IR_DOUBLE: IR_FOLD_CONST_D(*(double*)ptr);
+				case IR_FLOAT:  IR_FOLD_CONST_F(*(float*)ptr);
+				default:
+					IR_ASSERT(0);
+			}
+		}
+	}
+	IR_FOLD_NEXT;
 }
 
 IR_FOLD(INT2FP(C_I8))

--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -826,7 +826,7 @@ IR_ALWAYS_INLINE ir_ref ir_count_constant(const ir_ctx *ctx, ir_ref *_xlat, ir_r
 	if (!_xlat[ref]) {
 		_xlat[ref] = ref; /* this is only a "used constant" marker */
 		if (ctx->ir_base[ref].op == IR_LONG_CONST) {
-			ir_ref i, n = IR_ALIGNED_SIZE(ctx->ir_base[ref].long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+				ir_ref i, n = IR_ALIGNED_SIZE(ctx->ir_base[ref].long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
 
 			for (i = 1; i <= n; i++) {
 				_xlat[ref + i] = ref + i; /* this is only a "used constant" marker */
@@ -1330,10 +1330,23 @@ int ir_schedule(ir_ctx *ctx)
 		while (i < IR_TRUE) {
 			if (_xlat[i]) {
 				*dst = *src;
-				dst->prev_const = 0;
 				_xlat[i] = j;
-				dst++;
-				j++;
+				if (dst->op == IR_LONG_CONST) {
+					uintptr_t n;
+
+					memset(dst + 1, 0, dst->long_const_size);
+					memcpy(dst + 1, src + 1, dst->long_const_size);
+					n = IR_ALIGNED_SIZE(dst->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+					dst += n + 1;
+					src += n + 1;
+					i += n + 1;
+					j += n + 1;
+					continue;
+				} else {
+					dst->prev_const = 0;
+					dst++;
+					j++;
+				}
 			}
 			src++;
 			i++;

--- a/ir_gcm.c
+++ b/ir_gcm.c
@@ -821,10 +821,18 @@ static void ir_xlat_binding(ir_ctx *ctx, ir_ref *_xlat)
 	binding->count = n2;
 }
 
-IR_ALWAYS_INLINE ir_ref ir_count_constant(ir_ref *_xlat, ir_ref ref)
+IR_ALWAYS_INLINE ir_ref ir_count_constant(const ir_ctx *ctx, ir_ref *_xlat, ir_ref ref)
 {
 	if (!_xlat[ref]) {
 		_xlat[ref] = ref; /* this is only a "used constant" marker */
+		if (ctx->ir_base[ref].op == IR_LONG_CONST) {
+			ir_ref i, n = IR_ALIGNED_SIZE(ctx->ir_base[ref].long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+
+			for (i = 1; i <= n; i++) {
+				_xlat[ref + i] = ref + i; /* this is only a "used constant" marker */
+			}
+			return n + 1;
+		}
 		return 1;
 	}
 	return 0;
@@ -1063,7 +1071,7 @@ restart:
 						goto restart;
 					}
 				} else if (input < IR_TRUE) {
-					*consts_count += ir_count_constant(_xlat, input);
+					*consts_count += ir_count_constant(ctx, _xlat, input);
 				}
 			}
 		}
@@ -1160,16 +1168,16 @@ int ir_schedule(ir_ctx *ctx)
 		insn = &ctx->ir_base[i];
 		if (insn->op == IR_BEGIN) {
 			if (insn->op2) {
-				consts_count += ir_count_constant(_xlat, insn->op2);
+				consts_count += ir_count_constant(ctx, _xlat, insn->op2);
 			}
 		} else if (insn->op == IR_CASE_VAL) {
 			IR_ASSERT(insn->op2 < IR_TRUE);
-			consts_count += ir_count_constant(_xlat, insn->op2);
+			consts_count += ir_count_constant(ctx, _xlat, insn->op2);
 		} else if (insn->op == IR_CASE_RANGE) {
 			IR_ASSERT(insn->op2 < IR_TRUE);
-			consts_count += ir_count_constant(_xlat, insn->op2);
+			consts_count += ir_count_constant(ctx, _xlat, insn->op2);
 			IR_ASSERT(insn->op3 < IR_TRUE);
-			consts_count += ir_count_constant(_xlat, insn->op3);
+			consts_count += ir_count_constant(ctx, _xlat, insn->op3);
 		}
 		n = insn->inputs_count;
 		insns_count += ir_insn_inputs_to_len(n);
@@ -1196,7 +1204,7 @@ int ir_schedule(ir_ctx *ctx)
 				for (j = n, p = insn->ops + 2; j > 0; p++, j--) {
 					input = *p;
 					if (input < IR_TRUE) {
-						consts_count += ir_count_constant(_xlat, input);
+						consts_count += ir_count_constant(ctx, _xlat, input);
 					}
 				}
 				i = _next[i];
@@ -1237,7 +1245,7 @@ int ir_schedule(ir_ctx *ctx)
 								for (j = n, q = use_insn->ops + 2; j > 0; q++, j--) {
 									ir_ref input = *q;
 									if (input < IR_TRUE) {
-										consts_count += ir_count_constant(_xlat, input);
+										consts_count += ir_count_constant(ctx, _xlat, input);
 									}
 								}
 							} else {
@@ -1268,7 +1276,7 @@ int ir_schedule(ir_ctx *ctx)
 		insns_count++;
 		if (IR_INPUT_EDGES_COUNT(ir_op_flags[insn->op]) == 2) {
 			if (insn->op2 < IR_TRUE) {
-				consts_count += ir_count_constant(_xlat, insn->op2);
+				consts_count += ir_count_constant(ctx, _xlat, insn->op2);
 			}
 		}
 	}

--- a/ir_load.c
+++ b/ir_load.c
@@ -313,20 +313,22 @@ static uint64_t read_hex(const char *p, const char *e)
 #define YY_INT64_T 40
 #define YY_DOUBLE 41
 #define YY_FLOAT 42
-#define YY_NULL 43
-#define YY_INF 44
-#define YY_NAN 45
-#define YY__MINUS 46
-#define YY_ID 47
-#define YY_DECNUMBER 48
-#define YY_HEXNUMBER 49
-#define YY_FLOATNUMBER 50
-#define YY_CHARACTER 51
-#define YY_STRING 52
-#define YY_EOL 53
-#define YY_WS 54
-#define YY_ONE_LINE_COMMENT 55
-#define YY_COMMENT 56
+#define YY__LESS 43
+#define YY__GREATER 44
+#define YY_NULL 45
+#define YY_INF 46
+#define YY_NAN 47
+#define YY__MINUS 48
+#define YY_ID 49
+#define YY_DECNUMBER 50
+#define YY_HEXNUMBER 51
+#define YY_FLOATNUMBER 52
+#define YY_CHARACTER 53
+#define YY_STRING 54
+#define YY_EOL 55
+#define YY_WS 56
+#define YY_ONE_LINE_COMMENT 57
+#define YY_COMMENT 58
 
 static const char * sym_name[] = {
 	"<EOF>",
@@ -372,6 +374,8 @@ static const char * sym_name[] = {
 	"int64_t",
 	"double",
 	"float",
+	"<",
+	">",
 	"null",
 	"inf",
 	"nan",
@@ -458,6 +462,7 @@ static int parse_ir_func_name(int sym, char *buf);
 static int parse_ir_func_proto(int sym, ir_parser_ctx *p, uint32_t *flags, uint8_t *ret_type, uint32_t *params_count, uint8_t *param_types);
 static int parse_ir_insn(int sym, ir_parser_ctx *p);
 static int parse_ir_modifier(int sym, ir_parser_ctx *p);
+static int parse_simple_type(int sym, uint8_t *t);
 static int parse_type(int sym, uint8_t *t);
 static int parse_func(int sym, uint8_t *op);
 static int parse_val(int sym, ir_parser_ctx *p, uint8_t op, uint32_t n, ir_ref *ref);
@@ -494,21 +499,21 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch != 'n') goto _yy_tunnel_5;
 			ret = YY_EXTERN;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'v':
 			ch = *++YYPOS;
 			if (ch == 'a') {
 				ch = *++YYPOS;
 				if (ch != 'r') goto _yy_tunnel_5;
 				ret = YY_VAR;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'o') {
 				ch = *++YYPOS;
 				if (ch != 'i') goto _yy_tunnel_5;
 				ch = *++YYPOS;
 				if (ch != 'd') goto _yy_tunnel_5;
 				ret = YY_VOID;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else {
 				goto _yy_tunnel_5;
 			}
@@ -522,14 +527,14 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 't') goto _yy_tunnel_5;
 				ret = YY_CONST;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'h') {
 				ch = *++YYPOS;
 				if (ch != 'a') goto _yy_tunnel_5;
 				ch = *++YYPOS;
 				if (ch != 'r') goto _yy_tunnel_5;
 				ret = YY_CHAR;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else {
 				goto _yy_tunnel_5;
 			}
@@ -591,14 +596,14 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch != 'l') goto _yy_tunnel_5;
 			ret = YY_BYVAL;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'N':
 			ch = *++YYPOS;
 			if (ch != 'O') goto _yy_tunnel_5;
 			ch = *++YYPOS;
 			if (ch != 'P') goto _yy_tunnel_5;
 			ret = YY_NOP;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'b':
 			ch = *++YYPOS;
 			if (ch != 'o') goto _yy_tunnel_5;
@@ -607,7 +612,7 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch != 'l') goto _yy_tunnel_5;
 			ret = YY_BOOL;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'd':
 			ch = *++YYPOS;
 			if (ch != 'o') goto _yy_tunnel_5;
@@ -620,7 +625,7 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch != 'e') goto _yy_tunnel_5;
 			ret = YY_DOUBLE;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'f':
 			ch = *++YYPOS;
 			if (ch == 'l') {
@@ -631,14 +636,14 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 't') goto _yy_tunnel_5;
 				ret = YY_FLOAT;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'u') {
 				ch = *++YYPOS;
 				if (ch != 'n') goto _yy_tunnel_5;
 				ch = *++YYPOS;
 				if (ch != 'c') goto _yy_tunnel_5;
 				ret = YY_FUNC;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else {
 				goto _yy_tunnel_5;
 			}
@@ -648,7 +653,7 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch == 'f') {
 				ret = YY_INF;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 't') {
 				ch = *++YYPOS;
 				if (ch == '1') {
@@ -659,7 +664,7 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_INT16_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else if (ch == '3') {
 					ch = *++YYPOS;
 					if (ch != '2') goto _yy_tunnel_5;
@@ -668,7 +673,7 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_INT32_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else if (ch == '6') {
 					ch = *++YYPOS;
 					if (ch != '4') goto _yy_tunnel_5;
@@ -677,14 +682,14 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_INT64_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else if (ch == '8') {
 					ch = *++YYPOS;
 					if (ch != '_') goto _yy_tunnel_5;
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_INT8_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else {
 					goto _yy_tunnel_5;
 				}
@@ -701,21 +706,21 @@ _yy_state_start:
 			ch = *++YYPOS;
 			if (ch != 'l') goto _yy_tunnel_5;
 			ret = YY_LABEL;
-			goto _yy_state_209;
+			goto _yy_state_211;
 		case 'n':
 			ch = *++YYPOS;
 			if (ch == 'a') {
 				ch = *++YYPOS;
 				if (ch != 'n') goto _yy_tunnel_5;
 				ret = YY_NAN;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'u') {
 				ch = *++YYPOS;
 				if (ch != 'l') goto _yy_tunnel_5;
 				ch = *++YYPOS;
 				if (ch != 'l') goto _yy_tunnel_5;
 				ret = YY_NULL;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else {
 				goto _yy_tunnel_5;
 			}
@@ -731,12 +736,12 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 'c') goto _yy_tunnel_5;
 				ret = YY_STATIC;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'y') {
 				ch = *++YYPOS;
 				if (ch != 'm') goto _yy_tunnel_5;
 				ret = YY_SYM;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else {
 				goto _yy_tunnel_5;
 			}
@@ -759,7 +764,7 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_UINTPTR_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				case '1':
 					ch = *++YYPOS;
 					if (ch != '6') goto _yy_tunnel_5;
@@ -768,7 +773,7 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_UINT16_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				case '3':
 					ch = *++YYPOS;
 					if (ch != '2') goto _yy_tunnel_5;
@@ -777,7 +782,7 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_UINT32_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				case '6':
 					ch = *++YYPOS;
 					if (ch != '4') goto _yy_tunnel_5;
@@ -786,14 +791,14 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_UINT64_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				case '8':
 					ch = *++YYPOS;
 					if (ch != '_') goto _yy_tunnel_5;
 					ch = *++YYPOS;
 					if (ch != 't') goto _yy_tunnel_5;
 					ret = YY_UINT8_T;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				default:
 					goto _yy_tunnel_5;
 			}
@@ -815,7 +820,7 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 'n') goto _yy_tunnel_5;
 				ret = YY___BUILTIN;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'c') {
 				ch = *++YYPOS;
 				if (ch != 'o') goto _yy_tunnel_5;
@@ -826,7 +831,7 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 't') goto _yy_tunnel_5;
 				ret = YY___CONST;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'f') {
 				ch = *++YYPOS;
 				if (ch != 'a') goto _yy_tunnel_5;
@@ -843,7 +848,7 @@ _yy_state_start:
 				ch = *++YYPOS;
 				if (ch != 'l') goto _yy_tunnel_5;
 				ret = YY___FASTCALL;
-				goto _yy_state_209;
+				goto _yy_state_211;
 			} else if (ch == 'p') {
 				ch = *++YYPOS;
 				if (ch == 'r') {
@@ -870,14 +875,14 @@ _yy_state_start:
 					ch = *++YYPOS;
 					if (ch != 'e') goto _yy_tunnel_5;
 					ret = YY___PRESERVE_NONE;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else if (ch == 'u') {
 					ch = *++YYPOS;
 					if (ch != 'r') goto _yy_tunnel_5;
 					ch = *++YYPOS;
 					if (ch != 'e') goto _yy_tunnel_5;
 					ret = YY___PURE;
-					goto _yy_state_209;
+					goto _yy_state_211;
 				} else {
 					goto _yy_tunnel_5;
 				}
@@ -904,10 +909,58 @@ _yy_state_start:
 					goto _yy_state_error;
 				}
 			} else if ((ch >= '0' && ch <= '9')) {
-				goto _yy_state_62;
+				goto _yy_state_64;
 			} else {
 				goto _yy_state_error;
 			}
+		case '<':
+			YYPOS++;
+			ret = YY__LESS;
+			goto _yy_fin;
+		case '*':
+			YYPOS++;
+			ret = YY__STAR;
+			goto _yy_fin;
+		case '-':
+			ch = *++YYPOS;
+			accept = YY__MINUS;
+			accept_pos = YYPOS;
+			if ((ch >= '0' && ch <= '9')) {
+				goto _yy_state_24;
+			} else if (ch == '.') {
+				ch = *++YYPOS;
+				if ((ch >= '0' && ch <= '9')) {
+					goto _yy_state_64;
+				} else {
+					goto _yy_state_error;
+				}
+			} else {
+				ret = YY__MINUS;
+				goto _yy_fin;
+			}
+		case '0':
+			ch = *++YYPOS;
+			if (ch != 'x') goto _yy_tunnel_24;
+			ch = *++YYPOS;
+			if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f')) {
+				goto _yy_state_106;
+			} else {
+				goto _yy_state_error;
+			}
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			goto _yy_state_24;
+		case '>':
+			YYPOS++;
+			ret = YY__GREATER;
+			goto _yy_fin;
 		case ',':
 			YYPOS++;
 			ret = YY__COMMA;
@@ -924,42 +977,6 @@ _yy_state_start:
 			YYPOS++;
 			ret = YY__LBRACK;
 			goto _yy_fin;
-		case '-':
-			ch = *++YYPOS;
-			accept = YY__MINUS;
-			accept_pos = YYPOS;
-			if ((ch >= '0' && ch <= '9')) {
-				goto _yy_state_26;
-			} else if (ch == '.') {
-				ch = *++YYPOS;
-				if ((ch >= '0' && ch <= '9')) {
-					goto _yy_state_62;
-				} else {
-					goto _yy_state_error;
-				}
-			} else {
-				ret = YY__MINUS;
-				goto _yy_fin;
-			}
-		case '0':
-			ch = *++YYPOS;
-			if (ch != 'x') goto _yy_tunnel_26;
-			ch = *++YYPOS;
-			if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f')) {
-				goto _yy_state_104;
-			} else {
-				goto _yy_state_error;
-			}
-		case '1':
-		case '2':
-		case '3':
-		case '4':
-		case '5':
-		case '6':
-		case '7':
-		case '8':
-		case '9':
-			goto _yy_state_26;
 		case ']':
 			YYPOS++;
 			ret = YY__RBRACK;
@@ -977,25 +994,21 @@ _yy_state_start:
 			ret = YY__PLUS;
 			goto _yy_fin;
 		case '\'':
-			goto _yy_state_31;
+			goto _yy_state_34;
 		case '}':
 			YYPOS++;
 			ret = YY__RBRACE;
 			goto _yy_fin;
 		case '"':
-			goto _yy_state_33;
-		case '*':
-			YYPOS++;
-			ret = YY__STAR;
-			goto _yy_fin;
+			goto _yy_state_36;
 		case '/':
 			ch = *++YYPOS;
 			accept = YY__SLASH;
 			accept_pos = YYPOS;
 			if (ch == '*') {
-				goto _yy_state_74;
+				goto _yy_state_76;
 			} else if (ch == '/') {
-				goto _yy_state_39;
+				goto _yy_state_41;
 			} else {
 				ret = YY__SLASH;
 				goto _yy_fin;
@@ -1017,9 +1030,9 @@ _yy_state_start:
 		case '\t':
 		case '\f':
 		case '\v':
-			goto _yy_state_38;
+			goto _yy_state_40;
 		case '#':
-			goto _yy_state_39;
+			goto _yy_state_41;
 		case '\0':
 			if (ch == 0 && YYPOS < YYEND) goto _yy_state_error;
 			YYPOS++;
@@ -1037,22 +1050,22 @@ _yy_tunnel_5:
 		ret = YY_ID;
 		goto _yy_fin;
 	}
-_yy_state_26:
+_yy_state_24:
 	ch = *++YYPOS;
-_yy_tunnel_26:
+_yy_tunnel_24:
 	accept = YY_DECNUMBER;
 	accept_pos = YYPOS;
 	if ((ch >= '0' && ch <= '9')) {
-		goto _yy_state_26;
+		goto _yy_state_24;
 	} else if (ch == 'E' || ch == 'e') {
-		goto _yy_state_66;
+		goto _yy_state_68;
 	} else if (ch == '.') {
-		goto _yy_state_62;
+		goto _yy_state_64;
 	} else {
 		ret = YY_DECNUMBER;
 		goto _yy_fin;
 	}
-_yy_state_31:
+_yy_state_34:
 	ch = *++YYPOS;
 	if (ch == '\\') {
 		ch = *++YYPOS;
@@ -1060,7 +1073,7 @@ _yy_state_31:
 			if (ch == '\n') {
 				yy_line++;
 			}
-			goto _yy_state_31;
+			goto _yy_state_34;
 		} else {
 			goto _yy_state_error;
 		}
@@ -1072,11 +1085,11 @@ _yy_state_31:
 		if (ch == '\n') {
 			yy_line++;
 		}
-		goto _yy_state_31;
+		goto _yy_state_34;
 	} else {
 		goto _yy_state_error;
 	}
-_yy_state_33:
+_yy_state_36:
 	ch = *++YYPOS;
 	if (ch == '\\') {
 		ch = *++YYPOS;
@@ -1084,7 +1097,7 @@ _yy_state_33:
 			if (ch == '\n') {
 				yy_line++;
 			}
-			goto _yy_state_33;
+			goto _yy_state_36;
 		} else {
 			goto _yy_state_error;
 		}
@@ -1096,18 +1109,18 @@ _yy_state_33:
 		if (ch == '\n') {
 			yy_line++;
 		}
-		goto _yy_state_33;
+		goto _yy_state_36;
 	} else {
 		goto _yy_state_error;
 	}
-_yy_state_38:
+_yy_state_40:
 	ch = *++YYPOS;
 	if (ch == '\t' || ch == '\v' || ch == '\f' || ch == ' ') {
-		goto _yy_state_38;
+		goto _yy_state_40;
 	} else {
 		goto _yy_state_start;
 	}
-_yy_state_39:
+_yy_state_41:
 	ch = *++YYPOS;
 	if (ch == '\r') {
 		ch = *++YYPOS;
@@ -1123,69 +1136,69 @@ _yy_state_39:
 		YYPOS++;
 		goto _yy_state_start;
 	} else if (YYPOS < YYEND && (ch <= '\t' || ch == '\v' || ch == '\f' || ch >= '\016')) {
-		goto _yy_state_39;
+		goto _yy_state_41;
 	} else {
 		goto _yy_state_error;
 	}
-_yy_state_62:
+_yy_state_64:
 	ch = *++YYPOS;
 	accept = YY_FLOATNUMBER;
 	accept_pos = YYPOS;
 	if ((ch >= '0' && ch <= '9')) {
-		goto _yy_state_62;
+		goto _yy_state_64;
 	} else if (ch == 'E' || ch == 'e') {
-		goto _yy_state_66;
+		goto _yy_state_68;
 	} else {
 		ret = YY_FLOATNUMBER;
 		goto _yy_fin;
 	}
-_yy_state_66:
+_yy_state_68:
 	ch = *++YYPOS;
 	if (ch == '+' || ch == '-') {
 		ch = *++YYPOS;
 		if ((ch >= '0' && ch <= '9')) {
-			goto _yy_state_107;
+			goto _yy_state_109;
 		} else {
 			goto _yy_state_error;
 		}
 	} else if ((ch >= '0' && ch <= '9')) {
-		goto _yy_state_107;
+		goto _yy_state_109;
 	} else {
 		goto _yy_state_error;
 	}
-_yy_state_74:
+_yy_state_76:
 	ch = *++YYPOS;
-_yy_tunnel_74:
+_yy_tunnel_76:
 	if (ch == '*') {
 		ch = *++YYPOS;
-		if (ch != '/') goto _yy_tunnel_74;
+		if (ch != '/') goto _yy_tunnel_76;
 		YYPOS++;
 		goto _yy_state_start;
 	} else if (YYPOS < YYEND && (ch <= ')' || ch >= '+')) {
 		if (ch == '\n') {
 			yy_line++;
 		}
-		goto _yy_state_74;
+		goto _yy_state_76;
 	} else {
 		goto _yy_state_error;
 	}
-_yy_state_104:
+_yy_state_106:
 	ch = *++YYPOS;
 	if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f')) {
-		goto _yy_state_104;
+		goto _yy_state_106;
 	} else {
 		ret = YY_HEXNUMBER;
 		goto _yy_fin;
 	}
-_yy_state_107:
+_yy_state_109:
 	ch = *++YYPOS;
 	if ((ch >= '0' && ch <= '9')) {
-		goto _yy_state_107;
+		goto _yy_state_109;
 	} else {
 		ret = YY_FLOATNUMBER;
 		goto _yy_fin;
 	}
-_yy_state_209:
+_yy_state_211:
 	ch = *++YYPOS;
 	if (ch == '$' || ch == '.' || (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || ch == '_' || (ch >= 'a' && ch <= 'z')) {
 		goto _yy_state_5;
@@ -1311,7 +1324,7 @@ _yy_state_9:
 							yy_error_sym("'{' expected, got", sym);
 						}
 						sym = get_sym();
-						if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
+						if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS), "\000\000\000\300\377\017\000\000")) {
 							sym = parse_ir_sym_data(sym, loader);
 							while (1) {
 								save_pos  = yy_pos;
@@ -1329,7 +1342,7 @@ _yy_state_9:
 									yy_error_sym("unexpected", sym2);
 								}
 _yy_state_13_1:
-								if (YY_IN_SET(sym2, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
+								if (YY_IN_SET(sym2, (YY__LESS,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\017\000\000")) {
 									alt13 = 14;
 									goto _yy_state_13;
 								} else if (sym2 == YY__RBRACE) {
@@ -1508,7 +1521,7 @@ static int parse_ir_sym_data(int sym, ir_loader *loader) {
 				yy_error("sym_data_ref error");
 			}
 		}
-	} else if (YY_IN_SET(sym, (YY_DECNUMBER,YY_HEXNUMBER,YY_FLOATNUMBER,YY_CHARACTER,YY_INF,YY_NAN,YY__MINUS), "\000\000\000\000\000\160\017\000")) {
+	} else if (YY_IN_SET(sym, (YY_DECNUMBER,YY_HEXNUMBER,YY_FLOATNUMBER,YY_CHARACTER,YY_INF,YY_NAN,YY__MINUS), "\000\000\000\000\000\300\075\000")) {
 		sym = parse_const(sym, t, &val);
 		if (loader->sym_data) {
 			switch (ir_type_size[t]) {
@@ -1539,7 +1552,7 @@ static int parse_ir_func(int sym, ir_parser_ctx *p) {
 		yy_error_sym("'{' expected, got", sym);
 	}
 	sym = get_sym();
-	while (YY_IN_SET(sym, (YY_NOP,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY_ID), "\000\000\002\300\377\207\000\000")) {
+	while (YY_IN_SET(sym, (YY_NOP,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS,YY_ID), "\000\000\002\300\377\017\002\000")) {
 		if (sym == YY_NOP) {
 			sym = get_sym();
 		} else {
@@ -1592,14 +1605,14 @@ static int parse_ir_func_proto(int sym, ir_parser_ctx *p, uint32_t *flags, uint8
 	const unsigned char *save_pos;
 	const unsigned char *save_text;
 	int save_line;
-	int alt87;
+	int alt94;
 	uint8_t t = 0;
 	uint32_t n = 0;
 	if (sym != YY__LPAREN) {
 		yy_error_sym("'(' expected, got", sym);
 	}
 	sym = get_sym();
-	if (YY_IN_SET(sym, (YY_VOID,YY__POINT_POINT_POINT,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\014\300\377\007\000\000")) {
+	if (YY_IN_SET(sym, (YY_VOID,YY__POINT_POINT_POINT,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS), "\000\000\014\300\377\017\000\000")) {
 		if (sym == YY_VOID) {
 			sym = get_sym();
 		} else if (sym == YY__POINT_POINT_POINT) {
@@ -1612,32 +1625,32 @@ static int parse_ir_func_proto(int sym, ir_parser_ctx *p, uint32_t *flags, uint8
 				save_pos  = yy_pos;
 				save_text = yy_text;
 				save_line = yy_line;
-				alt87 = -2;
+				alt94 = -2;
 				sym2 = sym;
 				if (sym2 == YY__COMMA) {
 					sym2 = get_sym();
-					goto _yy_state_87_1;
+					goto _yy_state_94_1;
 				} else if (sym2 == YY__RPAREN) {
-					alt87 = 92;
-					goto _yy_state_87;
+					alt94 = 99;
+					goto _yy_state_94;
 				} else {
 					yy_error_sym("unexpected", sym2);
 				}
-_yy_state_87_1:
-				if (YY_IN_SET(sym2, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
-					alt87 = 88;
-					goto _yy_state_87;
+_yy_state_94_1:
+				if (YY_IN_SET(sym2, (YY__LESS,YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\017\000\000")) {
+					alt94 = 95;
+					goto _yy_state_94;
 				} else if (sym2 == YY__POINT_POINT_POINT) {
-					alt87 = 90;
-					goto _yy_state_87;
+					alt94 = 97;
+					goto _yy_state_94;
 				} else {
 					yy_error_sym("unexpected", sym2);
 				}
-_yy_state_87:
+_yy_state_94:
 				yy_pos  = save_pos;
 				yy_text = save_text;
 				yy_line = save_line;
-				if (alt87 != 88) {
+				if (alt94 != 95) {
 					break;
 				}
 				sym = get_sym();
@@ -1645,7 +1658,7 @@ _yy_state_87:
 				param_types[n++] = t;
 				if (n > 256) yy_error("name too params");
 			}
-			if (alt87 == 90) {
+			if (alt94 == 97) {
 				sym = get_sym();
 				if (sym != YY__POINT_POINT_POINT) {
 					yy_error_sym("'...' expected, got", sym);
@@ -1663,7 +1676,7 @@ _yy_state_87:
 		yy_error_sym("':' expected, got", sym);
 	}
 	sym = get_sym();
-	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
+	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS), "\000\000\000\300\377\017\000\000")) {
 		sym = parse_type(sym, ret_type);
 	} else if (sym == YY_VOID) {
 		sym = get_sym();
@@ -1713,7 +1726,7 @@ static int parse_ir_insn(int sym, ir_parser_ctx *p) {
 	uint32_t flags;
 	uint32_t params_count;
 	uint8_t param_types[IR_MAX_OPERANDS + 1];
-	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
+	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS), "\000\000\000\300\377\017\000\000")) {
 		sym = parse_type(sym, &t);
 		sym = parse_ID(sym, &str, &len);
 		if (sym == YY__COMMA) {
@@ -1808,7 +1821,7 @@ static int parse_ir_insn(int sym, ir_parser_ctx *p) {
 				ref = ref2 = ir_emit_N(p->ctx, IR_OPT(op, t), count.i32);
 				if (sym == YY__LPAREN) {
 					sym = get_sym();
-					if (YY_IN_SET(sym, (YY_ID,YY_STRING,YY_DECNUMBER,YY_NULL,YY_FUNC), "\000\000\001\000\000\210\021\000")) {
+					if (YY_IN_SET(sym, (YY_ID,YY_STRING,YY_DECNUMBER,YY_NULL,YY_FUNC), "\000\000\001\000\000\040\106\000")) {
 						p->curr_ref = ref;
 						sym = parse_val(sym, p, op, 1, &op1);
 						n = 1;
@@ -1846,7 +1859,7 @@ static int parse_ir_insn(int sym, ir_parser_ctx *p) {
 				n = 0;
 				if (sym == YY__LPAREN) {
 					sym = get_sym();
-					if (YY_IN_SET(sym, (YY_ID,YY_STRING,YY_DECNUMBER,YY_NULL,YY_FUNC), "\000\000\001\000\000\210\021\000")) {
+					if (YY_IN_SET(sym, (YY_ID,YY_STRING,YY_DECNUMBER,YY_NULL,YY_FUNC), "\000\000\001\000\000\040\106\000")) {
 						p->curr_ref = p->ctx->insns_count;
 						sym = parse_val(sym, p, op, 1, &op1);
 						n = 1;
@@ -2020,7 +2033,7 @@ static int parse_ir_modifier(int sym, ir_parser_ctx *p) {
 	return sym;
 }
 
-static int parse_type(int sym, uint8_t *t) {
+static int parse_simple_type(int sym, uint8_t *t) {
 	switch (sym) {
 		case YY_BOOL:
 			sym = get_sym();
@@ -2076,6 +2089,30 @@ static int parse_type(int sym, uint8_t *t) {
 			break;
 		default:
 			yy_error_sym("unexpected", sym);
+	}
+	return sym;
+}
+
+static int parse_type(int sym, uint8_t *t) {
+	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT), "\000\000\000\300\377\007\000\000")) {
+		sym = parse_simple_type(sym, t);
+	} else if (sym == YY__LESS) {
+		ir_val val;
+		sym = get_sym();
+		sym = parse_simple_type(sym, t);
+		if (sym != YY__STAR) {
+			yy_error_sym("'*' expected, got", sym);
+		}
+		sym = get_sym();
+		sym = parse_DECNUMBER(sym, IR_I32, &val);
+		if (sym != YY__GREATER) {
+			yy_error_sym("'>' expected, got", sym);
+		}
+		sym = get_sym();
+		if (val.u64 == 0 || val.u64 > 64 || (val.u64 & (val.u64 - 1)) != 0) yy_error("unsupported vector length");
+		*t = ir_make_vector_type(*t, val.u32);
+	} else {
+		yy_error_sym("unexpected", sym);
 	}
 	return sym;
 }

--- a/ir_load.c
+++ b/ir_load.c
@@ -1726,6 +1726,8 @@ static int parse_ir_insn(int sym, ir_parser_ctx *p) {
 	uint32_t flags;
 	uint32_t params_count;
 	uint8_t param_types[IR_MAX_OPERANDS + 1];
+	void *ptr;
+	ir_type t2;
 	if (YY_IN_SET(sym, (YY_BOOL,YY_UINT8_T,YY_UINT16_T,YY_UINT32_T,YY_UINT64_T,YY_UINTPTR_T,YY_CHAR,YY_INT8_T,YY_INT16_T,YY_INT32_T,YY_INT64_T,YY_DOUBLE,YY_FLOAT,YY__LESS), "\000\000\000\300\377\017\000\000")) {
 		sym = parse_type(sym, &t);
 		sym = parse_ID(sym, &str, &len);
@@ -1753,6 +1755,42 @@ static int parse_ir_insn(int sym, ir_parser_ctx *p) {
 			val.u64 = 0;
 			sym = parse_const(sym, t, &val);
 			ref = ir_const(p->ctx, val, t);
+			break;
+		case YY__LBRACE:
+			sym = get_sym();
+			ref = ir_const_vector(p->ctx, t);
+			ptr = ir_long_const_ptr(p->ctx, ref);
+			memset(ptr, 0, IR_VECTOR_SIZE(t));
+			t2 = IR_VECTOR_BASE_TYPE(t);
+			if (YY_IN_SET(sym, (YY_DECNUMBER,YY_HEXNUMBER,YY_FLOATNUMBER,YY_CHARACTER,YY_INF,YY_NAN,YY__MINUS), "\000\000\000\000\000\300\075\000")) {
+				sym = parse_const(sym, t2, &val);
+				switch (ir_type_size[2]) {
+					case 1: *(uint8_t*)ptr  = val.u8;  ptr = (char*)ptr + 1; break;
+					case 2: *(uint16_t*)ptr = val.u16; ptr = (char*)ptr + 2; break;
+					case 4: *(uint32_t*)ptr = val.u32; ptr = (char*)ptr + 4; break;
+					case 8: *(uint64_t*)ptr = val.u64; ptr = (char*)ptr + 8; break;
+					default:
+						IR_ASSERT(0);
+						break;
+				}
+				while (sym == YY__COMMA) {
+					sym = get_sym();
+					sym = parse_const(sym, t2, &val);
+					switch (ir_type_size[2]) {
+						case 1: *(uint8_t*)ptr  = val.u8;  ptr = (char*)ptr + 1; break;
+						case 2: *(uint16_t*)ptr = val.u16; ptr = (char*)ptr + 2; break;
+						case 4: *(uint32_t*)ptr = val.u32; ptr = (char*)ptr + 4; break;
+						case 8: *(uint64_t*)ptr = val.u64; ptr = (char*)ptr + 8; break;
+						default:
+							IR_ASSERT(0);
+							break;
+					}
+				}
+			}
+			if (sym != YY__RBRACE) {
+				yy_error_sym("'}' expected, got", sym);
+			}
+			sym = get_sym();
 			break;
 		case YY_FUNC:
 			sym = get_sym();

--- a/ir_load_llvm.c
+++ b/ir_load_llvm.c
@@ -56,6 +56,8 @@ static ir_type llvm2ir_type(LLVMTypeRef type)
 {
 	char *str;
 	uint32_t width;
+	ir_type element_type;
+	uint32_t count;
 
 	switch (LLVMGetTypeKind(type)) {
 		case LLVMVoidTypeKind:
@@ -88,7 +90,18 @@ static ir_type llvm2ir_type(LLVMTypeRef type)
 		case LLVMLabelTypeKind:
 			return IR_ADDR;
 		case LLVMVectorTypeKind:
-			IR_ASSERT(0 && "NIY LLVMVectorTypeKind use -fno-vectorize -fno-slp-vectorize");
+			element_type = llvm2ir_type(LLVMGetElementType(type));
+			count = LLVMGetVectorSize(type);
+			if (!IR_IS_TYPE_SCALAR(element_type)) {
+				fprintf(stderr, "Unsupported LLVM vector base type\n");
+				IR_ASSERT(0);
+			}
+			if (count == 0 || count > 64 || (count & (count - 1)) != 0) {
+				fprintf(stderr, "Unsupported LLVM vector length: %u\n", count);
+				IR_ASSERT(0);
+			}
+			return ir_make_vector_type(element_type, count);
+			//??? IR_ASSERT(0 && "NIY LLVMVectorTypeKind use -fno-vectorize -fno-slp-vectorize");
 		default:
 			break;
 	}

--- a/ir_main.c
+++ b/ir_main.c
@@ -827,8 +827,10 @@ static bool ir_loader_sym_dcl(ir_loader *loader, const char *name, uint32_t flag
 static bool ir_loader_sym_data(ir_loader *loader, ir_type type, uint32_t count, const void *data)
 {
 	ir_main_loader *l = (ir_main_loader*) loader;
-	size_t size = ir_type_size[type];
+	size_t size;
 
+	IR_ASSERT(IR_IS_TYPE_SCALAR(type));
+	size = ir_type_size[type];
 	if ((l->dump & IR_DUMP_IR) && (l->dump_file)) {
 		const void *p = data;
 		uint32_t i;

--- a/ir_mem2ssa.c
+++ b/ir_mem2ssa.c
@@ -537,7 +537,7 @@ static int ir_mem2ssa_may_convert_alloca(ir_ctx *ctx, ir_ref var, ir_ref next, i
 		if (use_insn->op == IR_LOAD) {
 			if (use_insn->op2 != var) {
 				return IR_CANNOT_CONVERT;
-			} else if (ir_type_size[use_insn->type] != size) {
+			} else if (ir_get_type_size(use_insn->type) != size) {
 				goto try_split;
 			}
 			if (!type) {
@@ -546,7 +546,7 @@ static int ir_mem2ssa_may_convert_alloca(ir_ctx *ctx, ir_ref var, ir_ref next, i
 		} else if (use_insn->op == IR_STORE) {
 			if (use_insn->op2 != var || use_insn->op3 == var) {
 				return IR_CANNOT_CONVERT;
-			} else if (ir_type_size[ctx->ir_base[use_insn->op3].type] != size) {
+			} else if (ir_get_type_size(ctx->ir_base[use_insn->op3].type) != size) {
 				goto try_split;
 			}
 			if (!type) {
@@ -605,6 +605,7 @@ static bool ir_mem2ssa_may_promote(ir_ctx *ctx, ir_mem2ssa_split_layout *layout,
 	ir_ref n, *p, use;
 	ir_insn *use_insn;
 	ir_use_list *use_list;
+	uint32_t use_size;
 
 	use_list = &ctx->use_lists[var];
 	n = use_list->count;
@@ -618,16 +619,18 @@ static bool ir_mem2ssa_may_promote(ir_ctx *ctx, ir_mem2ssa_split_layout *layout,
 			if (use_insn->op2 != var) {
 				return 0;
 			}
-			if (ir_type_size[use_insn->type] == layout->size
-			 || !ir_mem2ssa_add_split_var(ctx, layout, offset, ir_type_size[use_insn->type])) {
+			use_size = ir_get_type_size(use_insn->type);
+			if (use_size == layout->size
+			 || !ir_mem2ssa_add_split_var(ctx, layout, offset, use_size)) {
 				return 0;
 			}
 		} else if (use_insn->op == IR_STORE) {
 			if (use_insn->op2 != var || use_insn->op3 == var) {
 				return 0;
 			}
-			if (ir_type_size[ctx->ir_base[use_insn->op3].type] == layout->size
-			 || !ir_mem2ssa_add_split_var(ctx, layout, offset, ir_type_size[ctx->ir_base[use_insn->op3].type])) {
+			use_size = ir_get_type_size(ctx->ir_base[use_insn->op3].type);
+			if (use_size == layout->size
+			 || !ir_mem2ssa_add_split_var(ctx, layout, offset, use_size)) {
 				return 0;
 			}
 		} else {
@@ -645,6 +648,7 @@ static int ir_mem2ssa_may_split_alloca(ir_ctx *ctx, ir_mem2ssa_split_layout *lay
 	ir_ref n, *p, use;
 	ir_insn *use_insn;
 	ir_use_list *use_list;
+	uint32_t use_size;
 
 	use_list = &ctx->use_lists[var];
 	n = use_list->count;
@@ -663,16 +667,18 @@ static int ir_mem2ssa_may_split_alloca(ir_ctx *ctx, ir_mem2ssa_split_layout *lay
 			if (use_insn->op2 != var) {
 				return IR_CANNOT_CONVERT;
 			}
-			if (ir_type_size[use_insn->type] == layout->size
-			 || !ir_mem2ssa_add_split_var(ctx, layout, 0, ir_type_size[use_insn->type])) {
+			use_size = ir_get_type_size(use_insn->type);
+			if (use_size == layout->size
+			 || !ir_mem2ssa_add_split_var(ctx, layout, 0, use_size)) {
 				return IR_CANNOT_CONVERT;
 			}
 		} else if (use_insn->op == IR_STORE) {
 			if (use_insn->op2 != var || use_insn->op3 == var) {
 				return IR_CANNOT_CONVERT;
 			}
-			if (ir_type_size[ctx->ir_base[use_insn->op3].type] == layout->size
-			 || !ir_mem2ssa_add_split_var(ctx, layout, 0, ir_type_size[ctx->ir_base[use_insn->op3].type])) {
+			use_size = ir_get_type_size(ctx->ir_base[use_insn->op3].type);
+			if (use_size == layout->size
+			 || !ir_mem2ssa_add_split_var(ctx, layout, 0, use_size)) {
 				return IR_CANNOT_CONVERT;
 			}
 		} else if (use_insn->op == IR_ADD
@@ -782,6 +788,7 @@ static bool ir_mem2ssa_may_convert_var(ir_ctx *ctx, ir_ref var, ir_insn *insn)
 	ir_insn *use_insn;
 	ir_use_list *use_list;
 	ir_type type;
+	uint32_t size;
 
 	use_list = &ctx->use_lists[var];
 	n = use_list->count;
@@ -791,6 +798,7 @@ static bool ir_mem2ssa_may_convert_var(ir_ctx *ctx, ir_ref var, ir_insn *insn)
 
 	p = &ctx->use_edges[use_list->refs];
 	type = insn->type;
+	size = ir_get_type_size(type);
 	do {
 		use = *p;
 		IR_ASSERT(use);
@@ -798,14 +806,14 @@ static bool ir_mem2ssa_may_convert_var(ir_ctx *ctx, ir_ref var, ir_insn *insn)
 		if (use_insn->op == IR_VLOAD) {
 			if (use_insn->op2 != var
 			 || (use_insn->type != type
-			  && ir_type_size[use_insn->type] != ir_type_size[type])) {
+			  && ir_get_type_size(use_insn->type) != size)) {
 				return 0;
 			}
 		} else if (use_insn->op == IR_VSTORE) {
 			if (use_insn->op2 != var
 			 || use_insn->op3 == var
 			 || (ctx->ir_base[use_insn->op3].type != type
-			  && ir_type_size[ctx->ir_base[use_insn->op3].type] != ir_type_size[type])) {
+			  && ir_get_type_size(ctx->ir_base[use_insn->op3].type) != size)) {
 				return 0;
 			}
 		} else {

--- a/ir_private.h
+++ b/ir_private.h
@@ -884,11 +884,31 @@ void ir_addrtab_free(ir_hashtab *tab);
 ir_ref ir_addrtab_find(const ir_hashtab *tab, uint64_t key);
 void ir_addrtab_set(ir_hashtab *tab, uint64_t key, ir_ref val);
 
-/*** IR OP info ***/
+/*** IR Type info ***/
 extern const uint8_t ir_type_flags[IR_LAST_TYPE];
 extern const char *ir_type_name[IR_LAST_TYPE];
 extern const char *ir_type_cname[IR_LAST_TYPE];
 extern const uint8_t ir_type_size[IR_LAST_TYPE];
+
+#define IR_VECTOR_SIZE(t)                 (ir_type_size[IR_VECTOR_BASE_TYPE(t)] * IR_VECTOR_LENGTH(t))
+#define IR_MAKE_VECTOR_TYPE(base, length) ir_make_vector_type(base, length)
+
+IR_ALWAYS_INLINE ir_type ir_make_vector_type(ir_type base, uint8_t length)
+{
+	IR_ASSERT(IR_IS_TYPE_SCALAR(base) && length > 0 && length <= 64 && (length & (length - 1)) == 0);
+
+	return base | ((ir_ntz(length) + 1) << 4);
+}
+
+IR_ALWAYS_INLINE uint32_t ir_get_type_size(ir_type type)
+{
+#if IR_SIMD
+	if (IR_IS_TYPE_VECTOR(type)) return IR_VECTOR_SIZE(type);
+#endif
+	return ir_type_size[type];
+}
+
+/*** IR OP info ***/
 extern const uint32_t ir_op_flags[IR_LAST_OP];
 extern const char *ir_op_name[IR_LAST_OP];
 

--- a/ir_private.h
+++ b/ir_private.h
@@ -1047,6 +1047,7 @@ IR_ALWAYS_INLINE uint32_t ir_insn_len(const ir_insn *insn)
 #define IR_HAS_BLOCK_ADDR      (1<<12)
 #define IR_PREALLOCATED_STACK  (1<<13)
 #define IR_RECURSIVE_TAILCALL  (1<<14)
+#define IR_HAS_LONG_CONSTANTS  (1<<15)
 
 
 /* Temporary: MEM2SSA -> SCCP */

--- a/ir_ra.c
+++ b/ir_ra.c
@@ -2762,11 +2762,6 @@ static int32_t ir_allocate_small_spill_slot(ir_ctx *ctx, size_t size)
 	return ret;
 }
 
-int32_t ir_allocate_spill_slot(ir_ctx *ctx, ir_type type)
-{
-	return ir_allocate_small_spill_slot(ctx, ir_type_size[type]);
-}
-
 static int32_t ir_allocate_big_spill_slot(ir_ctx *ctx, int32_t size)
 {
 	int32_t ret;
@@ -2788,6 +2783,17 @@ static int32_t ir_allocate_big_spill_slot(ir_ctx *ctx, int32_t size)
 
 	return ret;
 }
+
+int32_t ir_allocate_spill_slot(ir_ctx *ctx, ir_type type)
+{
+	if (IR_IS_TYPE_SCALAR(type)) {
+		return ir_allocate_small_spill_slot(ctx, ir_type_size[type]);
+	} else {
+		IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+		return ir_allocate_big_spill_slot(ctx, IR_VECTOR_SIZE(type));
+	}
+}
+
 
 static ir_reg ir_get_first_reg_hint(ir_ctx *ctx, ir_live_interval *ival, ir_regset available)
 {
@@ -3066,7 +3072,7 @@ static ir_reg ir_try_allocate_free_reg(ir_ctx *ctx, ir_live_interval *ival, ir_l
 	ir_live_interval *other;
 	ir_regset available, overlapped, scratch;
 
-	if (IR_IS_TYPE_FP(ival->type)) {
+	if (IR_IS_TYPE_FP(ival->type) || IR_IS_TYPE_VECTOR(ival->type)) {
 		available = IR_REGSET_FP;
 		/* set freeUntilPos of all physical registers to maxInt */
 		for (i = IR_REG_FP_FIRST; i <= IR_REG_FP_LAST; i++) {
@@ -3404,7 +3410,7 @@ static ir_reg ir_allocate_blocked_reg(ir_ctx *ctx, ir_live_interval *ival, ir_li
 		next_use_pos = ival->range.end;
 	}
 
-	if (IR_IS_TYPE_FP(ival->type)) {
+	if (IR_IS_TYPE_FP(ival->type) || IR_IS_TYPE_VECTOR(ival->type)) {
 		available = IR_REGSET_FP;
 		/* set nextUsePos of all physical registers to maxInt */
 		for (i = IR_REG_FP_FIRST; i <= IR_REG_FP_LAST; i++) {
@@ -4141,18 +4147,21 @@ static int ir_linear_scan(ir_ctx *ctx, ir_ref vars)
 						} else {
 							active = other->list_next;
 						}
-						size = ir_type_size[other->type];
-						IR_ASSERT(size == 1 || size == 2 || size == 4 || size == 8);
-						old = handled[size];
-						while (old) {
-							if (old->stack_spill_pos == other->stack_spill_pos) {
-								break;
+						// TODO: reuse spill slots for vectors as well ???
+						if (IR_IS_TYPE_SCALAR(other->type)) {
+							size = ir_type_size[other->type];
+							IR_ASSERT(size == 1 || size == 2 || size == 4 || size == 8);
+							old = handled[size];
+							while (old) {
+								if (old->stack_spill_pos == other->stack_spill_pos) {
+									break;
+								}
+								old = old->list_next;
 							}
-							old = old->list_next;
-						}
-						if (!old) {
-							other->list_next = handled[size];
-							handled[size] = other;
+							if (!old) {
+								other->list_next = handled[size];
+								handled[size] = other;
+							}
 						}
 					} else {
 						prev = other;
@@ -4164,7 +4173,8 @@ static int ir_linear_scan(ir_ctx *ctx, ir_ref vars)
 				if (unhandled && ival->end > unhandled->range.start) {
 					ival->list_next = active;
 					active = ival;
-				} else {
+				// TODO: reuse spill slots for vectors as well ???
+				} else if (IR_IS_TYPE_SCALAR(ival->type)) {
 					size = ir_type_size[ival->type];
 					IR_ASSERT(size == 1 || size == 2 || size == 4 || size == 8);
 					old = handled[size];

--- a/ir_save.c
+++ b/ir_save.c
@@ -50,15 +50,25 @@ static void ir_print_call_conv(uint32_t flags, FILE *f)
 	}
 }
 
+static void ir_print_type_cname(ir_type type, FILE *f)
+{
+	if (IR_IS_TYPE_VECTOR(type)) {
+		fprintf(f, "<%s*%d>", ir_type_cname[IR_VECTOR_BASE_TYPE(type)], IR_VECTOR_LENGTH(type));
+	} else {
+		fprintf(f, "%s", ir_type_cname[type]);
+	}
+}
+
 void ir_print_proto_ex(uint8_t flags, ir_type ret_type, uint32_t params_count, const uint8_t *param_types, FILE *f)
 {
 	uint32_t j;
 
 	fprintf(f, "(");
 	if (params_count > 0) {
-		fprintf(f, "%s", ir_type_cname[param_types[0]]);
+		ir_print_type_cname(param_types[0], f);
 		for (j = 1; j < params_count; j++) {
-			fprintf(f, ", %s", ir_type_cname[param_types[j]]);
+			fprintf(f, ", ");
+			ir_print_type_cname(param_types[j], f);
 		}
 		if (flags & IR_VARARG_FUNC) {
 			fprintf(f, ", ...");
@@ -66,7 +76,8 @@ void ir_print_proto_ex(uint8_t flags, ir_type ret_type, uint32_t params_count, c
 	} else if (flags & IR_VARARG_FUNC) {
 		fprintf(f, "...");
 	}
-	fprintf(f, "): %s", ir_type_cname[ret_type]);
+	fprintf(f, "): ");
+	ir_print_type_cname(ret_type, f);
 	ir_print_call_conv(flags, f);
 	if (flags & IR_CONST_FUNC) {
 		fprintf(f, " __const");
@@ -86,10 +97,11 @@ void ir_print_func_proto(const ir_ctx *ctx, const char *name, bool prefix, FILE 
 	if (ctx->ir_base[2].op == IR_PARAM) {
 		ir_insn *insn = &ctx->ir_base[2];
 
-		fprintf(f, "%s", ir_type_cname[insn->type]);
+		ir_print_type_cname(insn->type, f);
 		insn++;
 		while (insn->op == IR_PARAM) {
-			fprintf(f, ", %s", ir_type_cname[insn->type]);
+			fprintf(f, ", ");
+			ir_print_type_cname(insn->type, f);
 			insn++;;
 		}
 		if (ctx->flags & IR_VARARG_FUNC) {
@@ -98,7 +110,8 @@ void ir_print_func_proto(const ir_ctx *ctx, const char *name, bool prefix, FILE 
 	} else if (ctx->flags & IR_VARARG_FUNC) {
 		fprintf(f, "...");
 	}
-	fprintf(f, "): %s", ir_type_cname[ctx->ret_type != (ir_type)-1 ? ctx->ret_type : IR_VOID]);
+	fprintf(f, "): ");
+	ir_print_type_cname(ctx->ret_type != (ir_type)-1 ? ctx->ret_type : IR_VOID, f);
 	ir_print_call_conv(ctx->flags, f);
 	if (ctx->flags & IR_CONST_FUNC) {
 		fprintf(f, " __const");
@@ -162,7 +175,9 @@ void ir_save(const ir_ctx *ctx, uint32_t save_flags, FILE *f)
 
 	fprintf(f, "{\n");
 	for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
-		fprintf(f, "\t%s c_%d = ", ir_type_cname[insn->type], i);
+		fprintf(f, "\t");
+		ir_print_type_cname(insn->type, f);
+		fprintf(f, " c_%d = ", i);
 		if (insn->op == IR_FUNC) {
 			fprintf(f, "func %s%s",
 				(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
@@ -243,7 +258,9 @@ void ir_save(const ir_ctx *ctx, uint32_t save_flags, FILE *f)
 			if (!(flags & IR_OP_FLAG_MEM) || insn->type == IR_VOID) {
 				fprintf(f, "\tl_%d = ", i);
 			} else {
-				fprintf(f, "\t%s d_%d", ir_type_cname[insn->type], i);
+				fprintf(f, "\t");
+				ir_print_type_cname(insn->type, f);
+				fprintf(f, " d_%d", i);
 				if (save_flags & IR_SAVE_REGS) {
 					if (ctx->vregs && ctx->vregs[i]) {
 						fprintf(f, " {R%d}", ctx->vregs[i]);
@@ -260,7 +277,8 @@ void ir_save(const ir_ctx *ctx, uint32_t save_flags, FILE *f)
 		} else {
 			fprintf(f, "\t");
 			if (flags & IR_OP_FLAG_DATA) {
-				fprintf(f, "%s d_%d", ir_type_cname[insn->type], i);
+				ir_print_type_cname(insn->type, f);
+				fprintf(f, " d_%d", i);
 				if (save_flags & IR_SAVE_REGS) {
 					if (ctx->vregs && ctx->vregs[i]) {
 						fprintf(f, " {R%d}", ctx->vregs[i]);

--- a/ir_save.c
+++ b/ir_save.c
@@ -50,7 +50,7 @@ static void ir_print_call_conv(uint32_t flags, FILE *f)
 	}
 }
 
-static void ir_print_type_cname(ir_type type, FILE *f)
+void ir_print_type_cname(ir_type type, FILE *f)
 {
 	if (IR_IS_TYPE_VECTOR(type)) {
 		fprintf(f, "<%s*%d>", ir_type_cname[IR_VECTOR_BASE_TYPE(type)], IR_VECTOR_LENGTH(type));

--- a/ir_save.c
+++ b/ir_save.c
@@ -174,31 +174,65 @@ void ir_save(const ir_ctx *ctx, uint32_t save_flags, FILE *f)
 	bool first;
 
 	fprintf(f, "{\n");
-	for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
-		fprintf(f, "\t");
-		ir_print_type_cname(insn->type, f);
-		fprintf(f, " c_%d = ", i);
-		if (insn->op == IR_FUNC) {
-			fprintf(f, "func %s%s",
-				(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
-				ir_get_str(ctx, insn->val.name));
-			ir_print_proto(ctx, insn->proto, f);
-		} else if (insn->op == IR_SYM) {
-			fprintf(f, "sym(%s%s)",
-				(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
-				ir_get_str(ctx, insn->val.name));
-		} else if (insn->op == IR_LABEL) {
-			fprintf(f, "label(%s%s)",
-				(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
-				ir_get_str(ctx, insn->val.name));
-		} else if (insn->op == IR_FUNC_ADDR) {
-			fprintf(f, "func *");
-			ir_print_const(ctx, insn, f, true);
-			ir_print_proto(ctx, insn->proto, f);
-		} else {
-			ir_print_const(ctx, insn, f, true);
+	/* Separate behavior to keep tests compatibility. TODO: remove the old behavior */
+	if (ctx->flags2 & IR_HAS_LONG_CONSTANTS) {
+		for (i = 1 - ctx->consts_count, insn = ctx->ir_base + i; i < IR_UNUSED; i++, insn++) {
+			fprintf(f, "\t");
+			ir_print_type_cname(insn->type, f);
+			fprintf(f, " c_%d = ", -i);
+			if (insn->op == IR_FUNC) {
+				fprintf(f, "func %s%s",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+				ir_print_proto(ctx, insn->proto, f);
+			} else if (insn->op == IR_SYM) {
+				fprintf(f, "sym(%s%s)",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_LABEL) {
+				fprintf(f, "label(%s%s)",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_FUNC_ADDR) {
+				fprintf(f, "func *");
+				ir_print_const(ctx, insn, f, true);
+				ir_print_proto(ctx, insn->proto, f);
+			} else {
+				ir_print_const(ctx, insn, f, true);
+			}
+			fprintf(f, ";\n");
+			if (insn->op == IR_LONG_CONST) {
+				i += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+				insn += IR_ALIGNED_SIZE(insn->long_const_size, sizeof(ir_insn)) / sizeof(ir_insn);
+			}
 		}
-		fprintf(f, ";\n");
+	} else {
+		for (i = IR_UNUSED + 1, insn = ctx->ir_base - i; i < ctx->consts_count; i++, insn--) {
+			fprintf(f, "\t");
+			ir_print_type_cname(insn->type, f);
+			fprintf(f, " c_%d = ", i);
+			if (insn->op == IR_FUNC) {
+				fprintf(f, "func %s%s",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+				ir_print_proto(ctx, insn->proto, f);
+			} else if (insn->op == IR_SYM) {
+				fprintf(f, "sym(%s%s)",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_LABEL) {
+				fprintf(f, "label(%s%s)",
+					(save_flags & IR_SAVE_SAFE_NAMES) ? "@" : "",
+					ir_get_str(ctx, insn->val.name));
+			} else if (insn->op == IR_FUNC_ADDR) {
+				fprintf(f, "func *");
+				ir_print_const(ctx, insn, f, true);
+				ir_print_proto(ctx, insn->proto, f);
+			} else {
+				ir_print_const(ctx, insn, f, true);
+			}
+			fprintf(f, ";\n");
+		}
 	}
 
 	for (i = IR_UNUSED + 1, insn = ctx->ir_base + i; i < ctx->insns_count;) {

--- a/ir_sccp.c
+++ b/ir_sccp.c
@@ -229,7 +229,7 @@ IR_ALWAYS_INLINE void ir_sccp_make_bottom_ex(const ir_ctx *ctx, ir_sccp_val *_va
 IR_ALWAYS_INLINE bool ir_sccp_meet_const(const ir_ctx *ctx, ir_sccp_val *_values, ir_bitqueue *worklist, ir_ref ref, const ir_insn *val_insn)
 {
 	if (IR_IS_TYPE_VECTOR(val_insn->type)) {
-		// TODO: vector constants are not implemented yet ???
+		// TODO: vector constants propagation is not implemented yet ???
 		IR_MAKE_BOTTOM_EX(ref);
 		return 1;
 	}

--- a/ir_sccp.c
+++ b/ir_sccp.c
@@ -228,6 +228,12 @@ IR_ALWAYS_INLINE void ir_sccp_make_bottom_ex(const ir_ctx *ctx, ir_sccp_val *_va
 
 IR_ALWAYS_INLINE bool ir_sccp_meet_const(const ir_ctx *ctx, ir_sccp_val *_values, ir_bitqueue *worklist, ir_ref ref, const ir_insn *val_insn)
 {
+	if (IR_IS_TYPE_VECTOR(val_insn->type)) {
+		// TODO: vector constants are not implemented yet ???
+		IR_MAKE_BOTTOM_EX(ref);
+		return 1;
+	}
+
 	IR_ASSERT(IR_IS_CONST_OP(val_insn->op) || IR_IS_SYM_CONST(val_insn->op));
 
 	if (_values[ref].op == IR_TOP) {
@@ -3472,7 +3478,9 @@ static void ir_iter_optimize_merge(ir_ctx *ctx, ir_ref merge_ref, ir_insn *merge
 						}
 					}
 				}
-				ir_optimize_phi(ctx, merge_ref, merge, phi_ref, phi);
+				if (IR_IS_TYPE_SCALAR(phi->type)) {
+					ir_optimize_phi(ctx, merge_ref, merge, phi_ref, phi);
+				}
 			}
 		}
 	}
@@ -3991,7 +3999,7 @@ remove_bitcast:
 				val = insn->op3;
 				val_insn = &ctx->ir_base[val];
 				if (val_insn->op == IR_BITCAST
-				 && ir_type_size[val_insn->type] == ir_type_size[ctx->ir_base[val_insn->op1].type]) {
+				 && ir_get_type_size(val_insn->type) == ir_get_type_size(ctx->ir_base[val_insn->op1].type)) {
 					insn->op3 = val_insn->op1;
 					ir_use_list_remove_one(ctx, val, i);
 					if (ctx->use_lists[val].count == 0) {

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -4389,6 +4389,46 @@ static void ir_emit_load_imm_fp(ir_ctx *ctx, ir_type type, ir_reg reg, ir_ref sr
 		}
 	} else {
 		label = ir_get_const_label(ctx, src);
+#if IR_SIMD
+		if (IR_IS_TYPE_VECTOR(type)) {
+			ir_type element_type = IR_VECTOR_BASE_TYPE(type);
+			uint32_t width = IR_VECTOR_SIZE(type);
+
+			if (ctx->mflags & IR_X86_AVX) {
+				if (width == 16) {
+					if (IR_IS_TYPE_INT(element_type)) {
+						|	vmovdqa xmm(reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_DOUBLE) {
+						|	vmovapd xmm(reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(element_type == IR_FLOAT);
+						|	vmovaps xmm(reg-IR_REG_FP_FIRST), [=>label]
+					}
+				} else {
+					IR_ASSERT(width == 32);
+					if (IR_IS_TYPE_INT(element_type)) {
+						|	vmovdqa ymm(reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_DOUBLE) {
+						|	vmovapd ymm(reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(element_type == IR_FLOAT);
+						|	vmovaps ymm(reg-IR_REG_FP_FIRST), [=>label]
+					}
+				}
+			} else {
+				IR_ASSERT(width == 16);
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	movdqa xmm(reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_DOUBLE) {
+					|	movapd xmm(reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	movaps xmm(reg-IR_REG_FP_FIRST), [=>label]
+				}
+			}
+			return;
+		}
+#endif
 		|	ASM_FP_REG_TXT_OP movs, type, reg, [=>label]
 	}
 }
@@ -20065,8 +20105,56 @@ next_block:;
 			}
 			|.byte 0
 
+		} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+			int label = ctx->cfg_blocks_count + i;
+			uint32_t size = IR_VECTOR_SIZE(insn->type);
+			uint32_t n = IR_VECTOR_LENGTH(insn->type);
+			ir_type type = IR_VECTOR_BASE_TYPE(insn->type);
+			void *p = ir_long_const_ptr(ctx, -i);
+
+			if (!data.rodata_label) {
+				data.rodata_label = ctx->cfg_blocks_count + ctx->consts_count + 2;
+
+				|.rodata
+				|=>data.rodata_label:
+			}
+			if (size >= 16) {
+				|.align 16
+			} else if (size == 8) {
+				|.align 8
+			} else if (size == 4) {
+				|.align 4
+			} else if (size == 2) {
+				|.align 2
+			}
+			|=>label:
+			if (ir_type_size[type] == 8) {
+				while (n--) {
+					ir_val val;
+					val.u64 = *(uint64_t*)p;
+					|.dword val.u32, val.u32_hi
+					p = (char*)p + 8;
+				}
+			} else if (ir_type_size[type] == 4) {
+				while (n--) {
+					|.dword *(uint32_t*)p
+					p = (char*)p + 4;
+				}
+			} else if (ir_type_size[type] == 2) {
+				while (n--) {
+					|.word *(uint16_t*)p
+					p = (char*)p + 2;
+				}
+			} else if (ir_type_size[type] == 1) {
+				while (n--) {
+					|.byte *(uint8_t*)p
+					p = (char*)p + 1;
+				}
+			} else {
+				IR_ASSERT(0);
+			}
 		} else {
-			IR_ASSERT(IR_IS_TYPE_FP(insn->type));
+			IR_ASSERT(IR_IS_TYPE_INT(insn->type));
 			int label = ctx->cfg_blocks_count + i;
 
 			if (!data.rodata_label) {

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -820,6 +820,244 @@ IR_ALWAYS_INLINE ir_mem IR_MEM(ir_reg base, int32_t offset, ir_reg index, int32_
 |	ASM_EXPAND_OP3_MEM ASM_AVX_REG_REG_TXT_OP, op, type, op1, op2, op3
 |.endmacro
 
+|.macro ASM_SSE_INT_VEC_REG_REG_OP, op, type, op1, op2
+||	if (type == IR_I8 || type == IR_U8) {
+|		op..b xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST)
+||	} else if (type == IR_I16 || type == IR_U16) {
+|		op..w xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST)
+||	} else if (type == IR_I32 || type == IR_U32) {
+|		op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST)
+||	} else if (type == IR_I64 || type == IR_U64) {
+|		op..q xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST)
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector type");
+||	}
+|.endmacro
+
+|.macro ASM_SSE_INT_VEC_REG_TXT_OP, op, type, op1, op2
+||	if (type == IR_I8 || type == IR_U8) {
+|		op..b xmm(op1-IR_REG_FP_FIRST), op2
+||	} else if (type == IR_I16 || type == IR_U16) {
+|		op..w xmm(op1-IR_REG_FP_FIRST), op2
+||	} else if (type == IR_I32 || type == IR_U32) {
+|		op..d xmm(op1-IR_REG_FP_FIRST), op2
+||	} else if (type == IR_I64 || type == IR_U64) {
+|		op..q xmm(op1-IR_REG_FP_FIRST), op2
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector type");
+||	}
+|.endmacro
+
+|.macro ASM_SSE_INT_VEC_REG_MEM_OP, op, type, op1, op2
+||	if (type == IR_I8 || type == IR_U8) {
+|		ASM_TXT_TMEM_OP op..b, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	} else if (type == IR_I16 || type == IR_U16) {
+|		ASM_TXT_TMEM_OP op..w, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	} else if (type == IR_I32 || type == IR_U32) {
+|		ASM_TXT_TMEM_OP op..d, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	} else if (type == IR_I64 || type == IR_U64) {
+|		ASM_TXT_TMEM_OP op..q, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector type");
+||	}
+|.endmacro
+
+|.macro ASM_SSE_FP_VEC_REG_REG_OP, op, type, op1, op2
+|	ASM_SSE2_REG_REG_OP op, type, op1, op2
+|.endmacro
+
+|.macro ASM_SSE_FP_VEC_REG_TXT_OP, op, type, op1, op2
+||	if (type == IR_DOUBLE) {
+|		op..d xmm(op1-IR_REG_FP_FIRST), op2
+||	} else {
+||		IR_ASSERT(type == IR_FLOAT);
+|		op..s xmm(op1-IR_REG_FP_FIRST), op2
+||	}
+|.endmacro
+
+|.macro ASM_SSE_FP_VEC_REG_MEM_OP, op, type, op1, op2
+||	if (type == IR_DOUBLE) {
+|		ASM_TXT_TMEM_OP op..d, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	} else {
+||		IR_ASSERT(type == IR_FLOAT);
+|		ASM_TXT_TMEM_OP op..s, xmm(op1-IR_REG_FP_FIRST), oword, op2
+||	}
+|.endmacro
+
+|.macro ASM_AVX_INT_VEC_REG_REG_REG_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			op..b xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			op..w xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			op..q xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST)
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			op..b ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			op..w ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			op..d ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			op..q ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_AVX_INT_VEC_REG_REG_TXT_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			op..b xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword op3
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			op..w xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword op3
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword op3
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			op..q xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword op3
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			op..b ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword op3
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			op..w ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword op3
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			op..d ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword op3
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			op..q ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword op3
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_AVX_INT_VEC_REG_REG_MEM_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			ASM_TXT_TXT_TMEM_OP op..b, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			ASM_TXT_TXT_TMEM_OP op..w, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			ASM_TXT_TXT_TMEM_OP op..d, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			ASM_TXT_TXT_TMEM_OP op..q, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_I8 || type == IR_U8) {
+|			ASM_TXT_TXT_TMEM_OP op..b, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		} else if (type == IR_I16 || type == IR_U16) {
+|			ASM_TXT_TXT_TMEM_OP op..w, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		} else if (type == IR_I32 || type == IR_U32) {
+|			ASM_TXT_TXT_TMEM_OP op..d, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		} else if (type == IR_I64 || type == IR_U64) {
+|			ASM_TXT_TXT_TMEM_OP op..q, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		} else {
+||			IR_ASSERT(0 && "unsupported vector type");
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_AVX_FP_VEC_REG_REG_REG_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+|		ASM_AVX_REG_REG_REG_OP op, type, op1, op2, op3
+||	} else if (width == 32) {
+||		if (type == IR_DOUBLE) {
+|			op..d ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			op..s ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST)
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_AVX_FP_VEC_REG_REG_TXT_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+||		if (type == IR_DOUBLE) {
+|			op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), op3
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			op..s xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), op3
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_DOUBLE) {
+|			op..d ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), op3
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			op..s ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), op3
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_AVX_FP_VEC_REG_REG_MEM_OP, op, type, width, op1, op2, op3
+||	if (width == 16) {
+||		if (type == IR_DOUBLE) {
+|			ASM_TXT_TXT_TMEM_OP op..d, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			ASM_TXT_TXT_TMEM_OP op..s, xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), oword, op3
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_DOUBLE) {
+|			ASM_TXT_TXT_TMEM_OP op..d, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			ASM_TXT_TXT_TMEM_OP op..s, ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), yword, op3
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
+|.macro ASM_SSE_FP_VEC_REG_REG_TXT_OP, op, type, op1, op2, op3
+||	if (type == IR_DOUBLE) {
+|		op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), op3
+||	} else {
+||		IR_ASSERT(type == IR_FLOAT);
+|		op..s xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), op3
+||	}
+|.endmacro
+
+|.macro ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP, op, type, width, op1, op2, op3, op4
+||	if (width == 16) {
+||		if (type == IR_DOUBLE) {
+|			op..d xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST), op4
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			op..s xmm(op1-IR_REG_FP_FIRST), xmm(op2-IR_REG_FP_FIRST), xmm(op3-IR_REG_FP_FIRST), op4
+||		}
+||	} else if (width == 32) {
+||		if (type == IR_DOUBLE) {
+|			op..d ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST), op4
+||		} else {
+||			IR_ASSERT(type == IR_FLOAT);
+|			op..s ymm(op1-IR_REG_FP_FIRST), ymm(op2-IR_REG_FP_FIRST), ymm(op3-IR_REG_FP_FIRST), op4
+||		}
+||	} else {
+||		IR_ASSERT(0 && "unsupported vector width");
+||	}
+|.endmacro
+
 |.macro ASM_FP_REG_REG_OP, op, type, op1, op2
 ||	if (ctx->mflags & IR_X86_AVX) {
 |		ASM_SSE2_REG_REG_OP v..op, type, op1, op2
@@ -967,7 +1205,7 @@ const char *ir_reg_name(int8_t reg, ir_type type)
 	if (type == IR_VOID) {
 		type = (reg < IR_REG_FP_FIRST) ? IR_ADDR : IR_DOUBLE;
 	}
-	if (IR_IS_TYPE_FP(type) || ir_type_size[type] == 8) {
+	if (!IR_IS_TYPE_INT(type) || ir_type_size[type] == 8) {
 		return _ir_reg_name[reg];
 	} else if (ir_type_size[type] == 4) {
 		return _ir_reg_name32[reg];
@@ -1256,6 +1494,17 @@ const ir_call_conv_dsc ir_call_conv_x86_fastcall = {
 	_(AND_ZEXT)            \
 	_(IGOTO_DUP)           \
 
+#if IR_SIMD
+# define IR_RULES_SIMD(_)  \
+	_(VECTOR_OP)           \
+	_(VECTOR_BINOP_SSE2)   \
+	_(VECTOR_BINOP_AVX)    \
+	_(VECTOR_SHIFT_SSE2)   \
+	_(VECTOR_SHIFT_AVX)    \
+	_(VECTOR_EXT)          \
+
+#endif
+
 #if IR_X86_I64
 # define IR_RULES_I64(_)   \
 	_(CMP_I64)             \
@@ -1297,6 +1546,9 @@ const ir_call_conv_dsc ir_call_conv_x86_fastcall = {
 enum _ir_rule {
 	IR_FIRST_RULE = IR_LAST_OP,
 	IR_RULES(IR_RULE_ENUM)
+#if IR_SIMD
+	IR_RULES_SIMD(IR_RULE_ENUM)
+#endif
 #if IR_X86_I64
 	IR_RULES_I64(IR_RULE_ENUM)
 #endif
@@ -1307,6 +1559,9 @@ enum _ir_rule {
 const char *ir_rule_name[IR_LAST_RULE] = {
 	NULL,
 	IR_RULES(IR_RULE_NAME)
+#if IR_X86_SIMD
+	IR_RULES_SIMD(IR_RULE_NAME)
+#endif
 #if IR_X86_I64
 	IR_RULES_I64(IR_RULE_NAME)
 #endif
@@ -2516,6 +2771,25 @@ static uint32_t ir_match_insn(ir_ctx *ctx, ir_ref ref)
 				}
 				ir_match_fuse_load_cmp_int(ctx, insn, ref);
 				return IR_CMP_INT;
+#if IR_SIMD
+			} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+binop_vector:
+				if (ir_op_flags[insn->op] & IR_OP_FLAG_COMMUTATIVE) {
+//					ir_match_fuse_load_commutative_fp(ctx, insn, ref);
+					if (ctx->mflags & IR_X86_AVX) {
+						return IR_VECTOR_BINOP_AVX;
+					} else {
+						return IR_VECTOR_BINOP_SSE2 | IR_MAY_SWAP;
+					}
+				} else {
+//					ir_match_fuse_load(ctx, insn->op2, ref);
+					if (ctx->mflags & IR_X86_AVX) {
+						return IR_VECTOR_BINOP_AVX;
+					} else {
+						return IR_VECTOR_BINOP_SSE2;
+					}
+				}
+#endif
 			} else {
 				ir_match_fuse_load_cmp_fp(ctx, insn, ref);
 				return IR_CMP_FP;
@@ -2523,6 +2797,11 @@ static uint32_t ir_match_insn(ir_ctx *ctx, ir_ref ref)
 			break;
 		case IR_ORDERED:
 		case IR_UNORDERED:
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 			ir_match_fuse_load_cmp_fp(ctx, insn, ref);
 			return IR_CMP_FP;
 		case IR_ADD:
@@ -2680,6 +2959,10 @@ binop_int:
 					ir_match_fuse_load(ctx, insn->op2, ref);
 					return IR_BINOP_INT;
 				}
+#if IR_SIMD
+			} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+#endif
 			} else {
 binop_fp:
 				if (ir_op_flags[insn->op] & IR_OP_FLAG_COMMUTATIVE) {
@@ -2744,6 +3027,10 @@ binop_fp:
 				}
 				ir_match_fuse_load(ctx, insn->op2, ref);
 				return IR_MUL_INT;
+#if IR_SIMD
+			} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+#endif
 			} else {
 				goto binop_fp;
 			}
@@ -2814,6 +3101,10 @@ binop_fp:
 				}
 				ir_match_fuse_load(ctx, insn->op2, ref);
 				return IR_DIV_INT;
+#if IR_SIMD
+			} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+#endif
 			} else {
 				goto binop_fp;
 			}
@@ -2892,6 +3183,11 @@ binop_fp:
 				return IR_OP_FP;
 			}
 		case IR_OR:
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 #if IR_X86_I64
 			if (insn->type == IR_I64 || insn->type == IR_U64) {
 				ir_match_fuse_load_commutative_int(ctx, insn, ref);
@@ -2917,6 +3213,11 @@ binop_fp:
 			}
 			goto binop_int;
 		case IR_AND:
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 #if IR_X86_I64
 			if (insn->type == IR_I64 || insn->type == IR_U64) {
 				ir_match_fuse_load_commutative_int(ctx, insn, ref);
@@ -2949,6 +3250,11 @@ binop_fp:
 			}
 			goto binop_int;
 		case IR_XOR:
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 #if IR_X86_I64
 			if (insn->type == IR_I64 || insn->type == IR_U64) {
 				ir_match_fuse_load_commutative_int(ctx, insn, ref);
@@ -2991,6 +3297,11 @@ binop_fp:
 #endif
 				return IR_SHIFT_CONST;
 			}
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 #if IR_X86_I64
 			if (insn->type == IR_I64 || insn->type == IR_U64) {
 				return IR_TWO_REGS | IR_SHIFT_I64;
@@ -3027,6 +3338,11 @@ binop_fp:
 #endif
 				return IR_SHIFT_CONST;
 			}
+#if IR_SIMD
+			if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+			}
+#endif
 #if IR_X86_I64
 			if (insn->type == IR_I64 || insn->type == IR_U64) {
 				return IR_TWO_REGS | IR_SHIFT_I64;
@@ -3042,6 +3358,10 @@ binop_fp:
 				}
 #endif
 				return IR_MIN_MAX_INT | IR_MAY_SWAP;
+#if IR_SIMD
+			} else if (IR_IS_TYPE_VECTOR(insn->type)) {
+				goto binop_vector;
+#endif
 			} else {
 				goto binop_fp;
 			}
@@ -4060,6 +4380,46 @@ static void ir_emit_load_mem_fp(ir_ctx *ctx, ir_type type, ir_reg reg, ir_mem me
 	ir_backend_data *data = ctx->data;
 	dasm_State **Dst = &data->dasm_state;
 
+#if IR_SIMD
+	if (IR_IS_TYPE_VECTOR(type)) {
+		ir_type element_type = IR_VECTOR_BASE_TYPE(type);
+		uint32_t width = IR_VECTOR_SIZE(type);
+
+		if (ctx->mflags & IR_X86_AVX) {
+			if (width == 16) {
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_TXT_TMEM_OP vmovdqa, xmm(reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_DOUBLE) {
+					|	ASM_TXT_TMEM_OP vmovapd, xmm(reg-IR_REG_FP_FIRST), oword, mem
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	ASM_TXT_TMEM_OP vmovaps, xmm(reg-IR_REG_FP_FIRST), oword, mem
+				}
+			} else {
+				IR_ASSERT(width == 32);
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_TXT_TMEM_OP vmovdqa, ymm(reg-IR_REG_FP_FIRST), yword, mem
+				} else if (element_type == IR_DOUBLE) {
+					|	ASM_TXT_TMEM_OP vmovapd, ymm(reg-IR_REG_FP_FIRST), yword, mem
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	ASM_TXT_TMEM_OP vmovaps, ymm(reg-IR_REG_FP_FIRST), yword, mem
+				}
+			}
+		} else {
+			IR_ASSERT(width == 16);
+			if (IR_IS_TYPE_INT(element_type)) {
+				|	ASM_TXT_TMEM_OP movdqa, xmm(reg-IR_REG_FP_FIRST), oword, mem
+			} else if (element_type == IR_DOUBLE) {
+				|	ASM_TXT_TMEM_OP movapd, xmm(reg-IR_REG_FP_FIRST), oword, mem
+			} else {
+				IR_ASSERT(element_type == IR_FLOAT);
+				|	ASM_TXT_TMEM_OP movaps, xmm(reg-IR_REG_FP_FIRST), oword, mem
+			}
+		}
+		return;
+	}
+#endif
 	|	ASM_FP_REG_MEM_OP movs, type, reg, mem
 }
 
@@ -4179,6 +4539,46 @@ static void ir_emit_store_mem_fp(ir_ctx *ctx, ir_type type, ir_mem mem, ir_reg r
 	ir_backend_data *data = ctx->data;
 	dasm_State **Dst = &data->dasm_state;
 
+#if IR_SIMD
+	if (IR_IS_TYPE_VECTOR(type)) {
+		ir_type element_type = IR_VECTOR_BASE_TYPE(type);
+		uint32_t width = IR_VECTOR_SIZE(type);
+
+		if (ctx->mflags & IR_X86_AVX) {
+			if (width == 16) {
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_TMEM_TXT_OP vmovdqa, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_DOUBLE) {
+					|	ASM_TMEM_TXT_OP vmovapd, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	ASM_TMEM_TXT_OP vmovaps, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+				}
+			} else {
+				IR_ASSERT(width == 32);
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_TMEM_TXT_OP vmovdqa, yword, mem, ymm(reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_DOUBLE) {
+					|	ASM_TMEM_TXT_OP vmovapd, yword, mem, ymm(reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	ASM_TMEM_TXT_OP vmovaps, yword, mem, ymm(reg-IR_REG_FP_FIRST)
+				}
+			}
+		} else {
+			IR_ASSERT(width == 16);
+			if (IR_IS_TYPE_INT(element_type)) {
+				|	ASM_TMEM_TXT_OP movdqa, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+			} else if (element_type == IR_DOUBLE) {
+				|	ASM_TMEM_TXT_OP movapd, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+			} else {
+				IR_ASSERT(element_type == IR_FLOAT);
+				|	ASM_TMEM_TXT_OP movaps, oword, mem, xmm(reg-IR_REG_FP_FIRST)
+			}
+		}
+		return;
+	}
+#endif
 	|	ASM_FP_MEM_REG_OP movs, type, mem, reg
 }
 
@@ -4372,6 +4772,46 @@ static void ir_emit_fp_mov(ir_ctx *ctx, ir_type type, ir_reg dst, ir_reg src)
 	ir_backend_data *data = ctx->data;
 	dasm_State **Dst = &data->dasm_state;
 
+#if IR_SIMD
+	if (IR_IS_TYPE_VECTOR(type)) {
+		ir_type element_type = IR_VECTOR_BASE_TYPE(type);
+		uint32_t width = IR_VECTOR_SIZE(type);
+
+		if (ctx->mflags & IR_X86_AVX) {
+			if (width <= 16) {
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	vmovdqa xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+				} else if (element_type == IR_DOUBLE) {
+					|	vmovapd xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	vmovaps xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+				}
+			} else {
+				IR_ASSERT(width <= 32);
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	vmovdqa ymm(dst-IR_REG_FP_FIRST), ymm(src-IR_REG_FP_FIRST)
+				} else if (element_type == IR_DOUBLE) {
+					|	vmovapd ymm(dst-IR_REG_FP_FIRST), ymm(src-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(element_type == IR_FLOAT);
+					|	vmovaps ymm(dst-IR_REG_FP_FIRST), ymm(src-IR_REG_FP_FIRST)
+				}
+			}
+		} else {
+			IR_ASSERT(width <= 16);
+			if (IR_IS_TYPE_INT(element_type)) {
+				|	movdqa xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+			} else if (element_type == IR_DOUBLE) {
+				|	movapd xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+			} else {
+				IR_ASSERT(element_type == IR_FLOAT);
+				|	movaps xmm(dst-IR_REG_FP_FIRST), xmm(src-IR_REG_FP_FIRST)
+			}
+		}
+		return;
+	}
+#endif
 	|	ASM_FP_REG_REG_OP movap, type, dst, src
 }
 
@@ -10811,7 +11251,7 @@ static int32_t ir_call_used_stack(ir_ctx *ctx, ir_insn *insn, const ir_call_conv
 				fp_param++;
 			}
 		} else {
-			IR_ASSERT(IR_IS_TYPE_FP(type));
+			IR_ASSERT(IR_IS_TYPE_FP(type) || IR_IS_TYPE_VECTOR(type));
 			if (fp_param >= cc->fp_param_regs_count) {
 				used_stack += IR_MAX(sizeof(void*), ir_type_size[type]);
 			}
@@ -11008,7 +11448,7 @@ static int32_t ir_emit_arguments(ir_ctx *ctx, ir_ref def, ir_insn *insn, const i
 				continue;
 			}
 		} else {
-			IR_ASSERT(IR_IS_TYPE_FP(type));
+			IR_ASSERT(IR_IS_TYPE_FP(type) || IR_IS_TYPE_VECTOR(type));
 			if (fp_param < cc->fp_param_regs_count) {
 				dst_reg = cc->fp_param_regs[fp_param];
 			} else {
@@ -11129,7 +11569,7 @@ static int32_t ir_emit_arguments(ir_ctx *ctx, ir_ref def, ir_insn *insn, const i
 					fp_param++;
 				}
 			} else {
-				IR_ASSERT(IR_IS_TYPE_FP(type));
+				IR_ASSERT(IR_IS_TYPE_FP(type) || IR_IS_TYPE_VECTOR(type));
 				if (fp_param < cc->fp_param_regs_count) {
 					dst_reg = cc->fp_param_regs[fp_param];
 				} else {
@@ -15357,6 +15797,2781 @@ static void ir_emit_return_i64(ir_ctx *ctx, ir_ref ref, ir_insn *insn)
 |.endif
 #endif
 
+#if IR_SIMD
+static void ir_emit_vector_extract(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = ctx->ir_base[insn->op1].type;
+	ir_type element_type;
+	uint32_t width;
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg tmp_reg = op1_reg;
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(insn->type == element_type);
+	IR_ASSERT(def_reg != IR_REG_NONE && op1_reg != IR_REG_NONE);
+
+	if (IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, insn->op1);
+	}
+
+	if (IR_IS_CONST_REF(insn->op2)) {
+		uint32_t lane = ctx->ir_base[insn->op2].val.u32;
+
+		if (IR_IS_TYPE_INT(element_type)) {
+			if (element_type == IR_I8 || element_type == IR_U8) {
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 16) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 16;
+						if (ctx->mflags & IR_X86_AVX2) {
+							|	vextracti128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						} else {
+							IR_ASSERT(ctx->mflags & IR_X86_AVX);
+							|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						}
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				if (ctx->mflags & IR_X86_AVX) {
+					|	vpextrb Ra(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else if (ctx->mflags & IR_X86_SSE41) {
+					|	pextrb Ra(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else {
+					|	pextrw Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), (lane/2)
+					if (lane % 2 == 0) {
+						|	shr Rd(def_reg), 8
+					}
+				}
+			} else if (element_type == IR_I16 || element_type == IR_U16) {
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 8) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 8;
+						if (ctx->mflags & IR_X86_AVX2) {
+							|	vextracti128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						} else {
+							IR_ASSERT(ctx->mflags & IR_X86_AVX);
+							|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						}
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				|	pextrw Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+			} else if (element_type == IR_I32 || element_type == IR_U32) {
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 4) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 4;
+						if (ctx->mflags & IR_X86_AVX2) {
+							|	vextracti128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						} else {
+							IR_ASSERT(ctx->mflags & IR_X86_AVX);
+							|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						}
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				if (lane == 0) {
+					|	movd Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST)
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vpextrd Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else if (ctx->mflags & IR_X86_SSE41) {
+					|	pextrd Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else {
+					op1_reg = tmp_reg;
+					tmp_reg = ctx->regs[def][3];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+
+					if (lane == 1) {
+						|	pshufd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), 85
+					} else if (lane == 2) {
+						|	punpckhdq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (lane == 3) {
+						|	pshufd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), 255
+					} else {
+						IR_ASSERT(0);
+					}
+					|	movd Rd(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST)
+				}
+#if defined(IR_TARGET_X64)
+|.if X64
+			} else if (element_type == IR_I64 || element_type == IR_U64) {
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 2) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 2;
+						if (ctx->mflags & IR_X86_AVX2) {
+							|	vextracti128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						} else {
+							IR_ASSERT(ctx->mflags & IR_X86_AVX);
+							|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+						}
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				if (lane == 0) {
+					|	movd Rq(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST)
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vpextrq Rq(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else if (ctx->mflags & IR_X86_SSE41) {
+					|	pextrq Rq(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST), lane
+				} else {
+					op1_reg = tmp_reg;
+					tmp_reg = ctx->regs[def][3];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+
+					IR_ASSERT(lane == 1);
+					|	movhlps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					|	movd Rq(def_reg), xmm(tmp_reg-IR_REG_FP_FIRST)
+				}
+|.endif
+#endif
+			} else {
+				IR_ASSERT(0 && "unsupprted vector type");
+			}
+		} else {
+			if (element_type == IR_DOUBLE) {
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 2) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 2;
+						IR_ASSERT(ctx->mflags & IR_X86_AVX);
+						|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				if (lane == 0) {
+					if (def_reg != op1_reg) {
+						|	movapd xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					}
+				} else if (lane == 1) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vunpckhpd xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						|	unpckhpd xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0);
+				}
+			} else {
+				IR_ASSERT(element_type == IR_FLOAT);
+				if (width == 16) {
+					tmp_reg = op1_reg;
+				} else if (width == 32) {
+					if (lane < 4) {
+						tmp_reg = op1_reg;
+					} else {
+						tmp_reg = ctx->regs[def][3];
+						IR_ASSERT(tmp_reg != IR_REG_NONE);
+						lane -= 4;
+						IR_ASSERT(ctx->mflags & IR_X86_AVX);
+						|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), 1
+					}
+				} else {
+					IR_ASSERT(0 && "unsupprted vector wdith");
+				}
+				if (lane == 0) {
+					if (def_reg != op1_reg) {
+						|	movaps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					}
+				} else if (lane == 1) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vshufps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), 85
+					} else {
+						|	shufps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), 85
+					}
+				} else if (lane == 2) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vunpckhps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						|	unpckhps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					}
+				} else if (lane == 3) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vshufps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), 255
+					} else {
+						|	shufps xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), 255
+					}
+				} else {
+					IR_ASSERT(0);
+				}
+			}
+		}
+	} else {
+		IR_ASSERT(0);
+	}
+
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_replace(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_reg op3_reg = ctx->regs[def][3];
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg tmp_reg = IR_REG_NONE;
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type) && type == ctx->ir_base[insn->op1].type);
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(element_type == ctx->ir_base[insn->op3].type);
+	IR_ASSERT(def_reg != IR_REG_NONE && op1_reg != IR_REG_NONE && op3_reg != IR_REG_NONE);
+
+	if (IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, insn->op1);
+	}
+	if (IR_REG_SPILLED(op3_reg)) {
+		op3_reg = IR_REG_NUM(op3_reg);
+		ir_emit_load(ctx, element_type, op3_reg, insn->op3);
+	}
+
+	if (IR_IS_CONST_REF(insn->op2)) {
+		uint32_t lane = ctx->ir_base[insn->op2].val.u32;
+
+		if (IR_IS_TYPE_INT(element_type)) {
+			if (width == 16) {
+				tmp_reg = def_reg;
+			} else if (width == 32) {
+				if (lane * ir_type_size[element_type] < 16) {
+					tmp_reg = def_reg;
+				} else {
+					tmp_reg = ctx->regs[def][2];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					if (ctx->mflags & IR_X86_AVX2) {
+						|	vextracti128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), 1
+					} else {
+						IR_ASSERT(ctx->mflags & IR_X86_AVX);
+						|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), 1
+					}
+				}
+			} else {
+				IR_ASSERT(0 && "unsupprted vector wdith");
+			}
+
+			if (element_type == IR_I8 || element_type == IR_U8) {
+				if (ctx->mflags & IR_X86_AVX) {
+					|	vpinsrb xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%16)
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					|	pinsrb xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%16)
+				} else {
+//???
+					IR_ASSERT(0 && "insert through mem");
+				}
+			} else if (element_type == IR_I16 || element_type == IR_U16) {
+				if (ctx->mflags & IR_X86_AVX) {
+					|	vpinsrw xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%8)
+				} else {
+					|	pinsrw xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%8)
+				}
+			} else if (element_type == IR_I32 || element_type == IR_U32) {
+				if (ctx->mflags & IR_X86_AVX) {
+					|	vpinsrd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%4)
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					|	pinsrd xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg), (lane%4)
+				} else {
+					tmp_reg = ctx->regs[def][2];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+
+					|	movd xmm(tmp_reg-IR_REG_FP_FIRST), Rd(op3_reg)
+					if (lane % 4 == 0) {
+						|	movss xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else if (lane % 4 == 1) {
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 225
+						|	movss xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 225
+					} else if (lane % 4 == 2) {
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 198
+						|	movss xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 198
+					} else if (lane % 4 == 3) {
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 39
+						|	movss xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+						|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 39
+					}
+				}
+#if defined(IR_TARGET_X64)
+|.if X64
+			} else if (element_type == IR_I64 || element_type == IR_U64) {
+				if (ctx->mflags & IR_X86_AVX) {
+					|	vpinsrq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), Rq(op3_reg), (lane%2)
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					|	pinsrq xmm(tmp_reg-IR_REG_FP_FIRST), Rq(op3_reg), (lane%2)
+				} else {
+					tmp_reg = ctx->regs[def][2];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+
+					|	movd xmm(tmp_reg-IR_REG_FP_FIRST), Rq(op3_reg)
+					if (lane % 2 == 0) {
+						|	movsd xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						|	punpcklqdq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					}
+				}
+|.endif
+#endif
+			} else {
+				IR_ASSERT(0);
+			}
+
+			if (width == 32) {
+				int idx = lane * ir_type_size[element_type] >= 16;
+				if (ctx->mflags & IR_X86_AVX2) {
+					|	vinserti128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), idx
+				} else {
+					IR_ASSERT(ctx->mflags & IR_X86_AVX);
+					|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), idx
+				}
+			}
+		} else {
+			if (width == 16) {
+				tmp_reg = def_reg;
+			} else if (width == 32) {
+				if (lane * ir_type_size[element_type] < 16) {
+					tmp_reg = def_reg;
+				} else {
+					tmp_reg = ctx->regs[def][2];
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					IR_ASSERT(ctx->mflags & IR_X86_AVX);
+					|	vextractf128 xmm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), 1
+				}
+			} else {
+				IR_ASSERT(0 && "unsupprted vector wdith");
+			}
+
+			if (element_type == IR_DOUBLE) {
+				if (lane % 2 == 0) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vmovsd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					} else {
+						|	movsd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vunpcklpd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					} else {
+						|	unpcklpd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					}
+				}
+			} else {
+				if (lane % 2 == 0) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vmovss xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					} else {
+						|	movss xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST)
+					}
+				} else if (lane % 1 == 1) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vinsertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 16
+					} else {
+						|	insertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 16
+					}
+				} else if (lane % 1 == 2) {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vinsertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 32
+					} else {
+						|	insertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 32
+					}
+				} else {
+					if (ctx->mflags & IR_X86_AVX) {
+						|	vinsertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 48
+					} else {
+						|	insertps xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op3_reg-IR_REG_FP_FIRST), 48
+					}
+				}
+			}
+
+			if (width == 32) {
+				int idx = lane * ir_type_size[element_type] >= 16;
+
+				IR_ASSERT(ctx->mflags & IR_X86_AVX);
+				|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), idx
+			}
+		}
+	} else {
+		IR_ASSERT(0);
+	}
+
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_splat(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(element_type == ctx->ir_base[insn->op1].type);
+	IR_ASSERT(def_reg != IR_REG_NONE);
+
+	if (op1_reg != IR_REG_NONE) {
+		if (IR_REG_SPILLED(op1_reg)) {
+			op1_reg = IR_REG_NUM(op1_reg);
+			ir_emit_load(ctx, type, op1_reg, insn->op1);
+		}
+		if (IR_IS_TYPE_INT(element_type)) {
+			if (element_type == IR_I8 || element_type == IR_U8) {
+				if (ctx->mflags & IR_X86_AVX2) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					if (width == 16) {
+						|	vpbroadcastb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						|	vpbroadcastb ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+				} else if (ctx->mflags & IR_X86_AVX) {
+					ir_reg tmp_reg = ctx->regs[def][2];
+
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	vpxor xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					|	vpshufb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					if (width == 32) {
+						|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 1
+					}
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					ir_reg tmp_reg = ctx->regs[def][2];
+
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	pxor xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					|	pshufb xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	punpcklbw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					|	punpcklwd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+				}
+			} else if (element_type == IR_I16 || element_type == IR_U16) {
+				if (ctx->mflags & IR_X86_AVX2) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					if (width == 16) {
+						|	vpbroadcastw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						|	vpbroadcastw ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+#if 0
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+//??? {0,1,0,1,0,1,0,1,0,1,0,1}
+					|	vpshufb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					if (width == 32) {
+						|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 1
+					}
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+//??? {0,1,0,1,0,1,0,1,0,1,0,1}
+					|	pshufb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+#endif
+				} else {
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	punpcklwd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+				}
+			} else if (element_type == IR_I32 || element_type == IR_U32) {
+				if (ctx->mflags & IR_X86_AVX2) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					if (width == 16) {
+						|	vpbroadcastd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						|	vpbroadcastd ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	vpshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+				} else {
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rd(op1_reg)
+					|	pshufd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+				}
+#if defined(IR_TARGET_X64)
+|.if X64
+			} else if (element_type == IR_I64 || element_type == IR_U64) {
+				if (ctx->mflags & IR_X86_AVX2) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rq(op1_reg)
+					if (width == 16) {
+						|	vpbroadcastq xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						|	vpbroadcastq ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vmovd xmm(def_reg-IR_REG_FP_FIRST), Rq(op1_reg)
+					|	vpunpcklqdq xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					if (width == 32) {
+						|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 1
+					}
+				} else {
+					IR_ASSERT(width == 16);
+					|	movd xmm(def_reg-IR_REG_FP_FIRST), Rq(op1_reg-IR_REG_FP_FIRST)
+					|	punpcklqdq xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+				}
+|.endif
+#endif
+			} else {
+				IR_ASSERT(0);
+			}
+		} else {
+			if (element_type == IR_DOUBLE) {
+				if (ctx->mflags & IR_X86_AVX) {
+					if (width == 16) {
+						|	vmovddup xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						if (ctx->mflags & IR_X86_AVX2) {
+							|	vbroadcastsd ymm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else {
+							|	vmovddup xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+							|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 1
+						}
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+				} else if (ctx->mflags & IR_X86_SSE42) {
+					IR_ASSERT(width == 16);
+					|	movddup xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(width == 16);
+					if (def_reg != op1_reg) {
+						|	movapd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+					|	unpcklpd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+				}
+			} else {
+				IR_ASSERT(element_type == IR_FLOAT);
+				if (ctx->mflags & IR_X86_AVX2) {
+					if (width == 16) {
+						|	vbroadcastss xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (width == 16) {
+						|	vbroadcastss ymm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupprted vector wdith");
+					}
+				} else if (ctx->mflags & IR_X86_AVX) {
+					|	vshufps xmm(op1_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+					if (width == 32) {
+						|	vinsertf128 ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 1
+					}
+				} else {
+					IR_ASSERT(width == 16);
+					|	shufps xmm(op1_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), 0
+				}
+			}
+		}
+	} else {
+		IR_ASSERT(0);
+	}
+
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_op(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_ref tmp_reg = ctx->regs[def][2];
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(type == ctx->ir_base[insn->op1].type);
+	IR_ASSERT(def_reg != IR_REG_NONE && op1_reg != IR_REG_NONE);
+	if (IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, insn->op1);
+	}
+
+	switch (insn->op) {
+		default:
+		case IR_NEG:
+		case IR_ABS:
+			if (IR_IS_TYPE_INT(element_type)) {
+			} else {
+			}
+			IR_ASSERT(0 && "NIY binary op");
+			break;
+		case IR_NOT:
+			IR_ASSERT(IR_IS_TYPE_INT(element_type));
+			IR_ASSERT(tmp_reg != IR_REG_NONE);
+			if (ctx->mflags & IR_X86_AVX) {
+				if (width == 16) {
+					|	vpcmpeqd xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+				} else if (width == 32) {
+					|	vpcmpeqd ymm(tmp_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST)
+					|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else {
+				IR_ASSERT(width == 16);
+				|	pcmpeqd	xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+				|	pxor xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+			}
+			break;
+	}
+}
+
+static void ir_emit_vector_binop_sse2(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_ref op1 = insn->op1;
+	ir_ref op2 = insn->op2;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_reg op2_reg = ctx->regs[def][2];
+	ir_reg tmp_reg = ctx->regs[def][3];
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(width <= 16);
+	IR_ASSERT(type == ctx->ir_base[op1].type && type == ctx->ir_base[op2].type);
+	IR_ASSERT(def_reg != IR_REG_NONE);
+
+	if (op1_reg != IR_REG_NONE && IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, op1);
+	}
+	if (def_reg != op1_reg) {
+		if (op1_reg != IR_REG_NONE) {
+			ir_emit_fp_mov(ctx, type, def_reg, op1_reg);
+		} else {
+			ir_emit_load(ctx, type, def_reg, op1);
+		}
+		if (op1 == op2) {
+			op2_reg = def_reg;
+		}
+	}
+	if (op2_reg != IR_REG_NONE) {
+		if (IR_REG_SPILLED(op2_reg)) {
+			op2_reg = IR_REG_NUM(op2_reg);
+			if (op1 != op2) {
+				ir_emit_load(ctx, type, op2_reg, op2);
+			}
+		}
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_REG_OP padd, element_type, def_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_OP addp, element_type, def_reg, op2_reg
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_REG_OP psub, element_type, def_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_OP subp, element_type, def_reg, op2_reg
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	pmullw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	pmulld xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_OP mulp, element_type, def_reg, op2_reg
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_SSE_FP_VEC_REG_REG_OP divp, element_type, def_reg, op2_reg
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	pminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U8) {
+						|	pminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16) {
+						|	pminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U16) {
+						|	pminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32) {
+						|	pminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U32) {
+						|	pminud xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_OP minp, element_type, def_reg, op2_reg
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	pmaxsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U8) {
+						|	pmaxub xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16) {
+						|	pmaxsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U16) {
+						|	pmaxuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32) {
+						|	pmaxsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U32) {
+						|	pmaxud xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_OP maxp, element_type, def_reg, op2_reg
+				}
+				break;
+			case IR_AND:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	pand xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				break;
+			case IR_OR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	por xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				break;
+			case IR_XOR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	pxor xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				break;
+			case IR_EQ:
+				|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpeq, element_type, def_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 0
+				}
+				break;
+			case IR_NE:
+				|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				if (IR_IS_TYPE_INT(element_type)) {
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpeq, element_type, def_reg, op2_reg
+					|	pxor xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpeq, element_type, def_reg, tmp_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 4
+				}
+				break;
+			case IR_LT:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpgt, element_type, def_reg, op1_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 1
+				}
+				break;
+			case IR_GT:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpgt, element_type, def_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op1_reg, 1
+				}
+				break;
+			case IR_LE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8 || element_type == IR_U8) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16 || element_type == IR_U16) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32|| element_type == IR_U32) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I64 || element_type == IR_U64) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						|	pcmpeqq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 2
+				}
+				break;
+			case IR_GE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8 || element_type == IR_U8) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16 || element_type == IR_U16) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32|| element_type == IR_U32) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I64 || element_type == IR_U64) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						|	pcmpeqq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op2_reg, op1_reg, 2
+				}
+				break;
+			case IR_ULT:
+				if (IR_IS_TYPE_INT(element_type)) {
+//???					|	ASM_SSE_INT_VEC_REG_REG_OP pcmpgt, element_type, def_reg, op2_reg, op1_reg
+					IR_ASSERT(0 && "unsupported vector type");
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op1_reg, 6
+				}
+				break;
+			case IR_UGT:
+				if (IR_IS_TYPE_INT(element_type)) {
+//???					|	ASM_SSE_INT_VEC_REG_REG_REG_OP vpcmpgt, element_type, def_reg, op1_reg, op2_reg
+					IR_ASSERT(0 && "unsupported vector type");
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 6
+				}
+				break;
+			case IR_ULE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8 || element_type == IR_U8) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16 || element_type == IR_U16) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32|| element_type == IR_U32) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+//???				} else if (element_type == IR_I64 || element_type == IR_U64) {
+//						|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+//						|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+//						|	vpcmpeqq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op1_reg, 5
+				}
+				break;
+			case IR_UGE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8 || element_type == IR_U8) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I16 || element_type == IR_U16) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32|| element_type == IR_U32) {
+						|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						|	pminud xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						|	pcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+//???				} else if (element_type == IR_I64 || element_type == IR_U64) {
+//						|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+//						|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+//						|	vpcmpeqq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 5
+				}
+				break;
+			case IR_ORDERED:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 7
+				break;
+			case IR_UNORDERED:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	movdqa xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				|	ASM_SSE_FP_VEC_REG_REG_TXT_OP cmpp, element_type, def_reg, op2_reg, 3
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16 || element_type == IR_U16) {
+					|	psllw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	pslld xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	psllq xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16) {
+					|	psraw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_U16) {
+					|	psrlw xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_I32) {
+					|	psrad xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_U32) {
+					|	psrld xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (element_type == IR_U64) {
+					|	psrlq xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+		}
+	} else if (IR_IS_CONST_REF(op2)) {
+		int label = ir_get_const_label(ctx, op2);
+
+		IR_ASSERT(width == 16);
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_TXT_OP padd, element_type, def_reg, [=>label]
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_TXT_OP addp, element_type, def_reg, [=>label]
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_TXT_OP psub, element_type, def_reg, [=>label]
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_TXT_OP subp, element_type, def_reg, [=>label]
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	pmullw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	pmulld xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_TXT_OP mulp, element_type, def_reg, [=>label]
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_SSE_FP_VEC_REG_TXT_OP divp, element_type, def_reg, [=>label]
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	pminsb xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U8) {
+						|	pminub xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I16) {
+						|	pminsw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U16) {
+						|	pminuw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32) {
+						|	pminsd xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U32) {
+						|	pminud xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_TXT_OP minp, element_type, def_reg, [=>label]
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	pmaxsb xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U8) {
+						|	pmaxub xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I16) {
+						|	pmaxsw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U16) {
+						|	pmaxuw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32) {
+						|	pmaxsd xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U32) {
+						|	pmaxud xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_TXT_OP maxp, element_type, def_reg, [=>label]
+				}
+				break;
+			case IR_AND:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	pand xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				break;
+			case IR_OR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	por xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				break;
+			case IR_XOR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	pxor xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16 || element_type == IR_U16) {
+					|	psllw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	pslld xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	psllq xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16) {
+					|	psraw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_U16) {
+					|	psrlw xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_I32) {
+					|	psrad xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_U32) {
+					|	psrld xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (element_type == IR_U64) {
+					|	psrlq xmm(def_reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+		}
+	} else {
+		ir_mem mem;
+
+		IR_ASSERT(width == 16);
+		if (ir_rule(ctx, op2) & IR_FUSED) {
+			mem = ir_fuse_load(ctx, def, op2);
+		} else {
+			mem = ir_ref_spill_slot(ctx, op2);
+		}
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_MEM_OP padd, element_type, def_reg, mem
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_MEM_OP addp, element_type, def_reg, mem
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_SSE_INT_VEC_REG_MEM_OP psub, element_type, def_reg, mem
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_MEM_OP subp, element_type, def_reg, mem
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	ASM_TXT_TMEM_OP pmullw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	ASM_TXT_TMEM_OP pmulld, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_MEM_OP mulp, element_type, def_reg, mem
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_SSE_FP_VEC_REG_MEM_OP divp, element_type, def_reg, mem
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	ASM_TXT_TMEM_OP pminsb, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U8) {
+						|	ASM_TXT_TMEM_OP pminub, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I16) {
+						|	ASM_TXT_TMEM_OP pminsw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U16) {
+						|	ASM_TXT_TMEM_OP pminuw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32) {
+						|	ASM_TXT_TMEM_OP pminsd, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U32) {
+						|	ASM_TXT_TMEM_OP pminud, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_MEM_OP minp, element_type, def_reg, mem
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (element_type == IR_I8) {
+						|	ASM_TXT_TMEM_OP pmaxsb, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U8) {
+						|	ASM_TXT_TMEM_OP pmaxub, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I16) {
+						|	ASM_TXT_TMEM_OP pmaxsw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U16) {
+						|	ASM_TXT_TMEM_OP pmaxuw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32) {
+						|	ASM_TXT_TMEM_OP pmaxsd, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U32) {
+						|	ASM_TXT_TMEM_OP pmaxud, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_SSE_FP_VEC_REG_MEM_OP maxp, element_type, def_reg, mem
+				}
+				break;
+			case IR_AND:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	ASM_TXT_TMEM_OP pand, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				break;
+			case IR_OR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	ASM_TXT_TMEM_OP por, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				break;
+			case IR_XOR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				|	ASM_TXT_TMEM_OP pxor, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16 || element_type == IR_U16) {
+					|	ASM_TXT_TMEM_OP psllw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	ASM_TXT_TMEM_OP pslld, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	ASM_TXT_TMEM_OP psllq, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (element_type == IR_I16) {
+					|	ASM_TXT_TMEM_OP psraw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_U16) {
+					|	ASM_TXT_TMEM_OP psrlw, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_I32) {
+					|	ASM_TXT_TMEM_OP psrad, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_U32) {
+					|	ASM_TXT_TMEM_OP psrld, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else if (element_type == IR_U64) {
+					|	ASM_TXT_TMEM_OP psrlq, xmm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+				break;
+		}
+	}
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_binop_avx(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_ref op1 = insn->op1;
+	ir_ref op2 = insn->op2;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+	ir_reg op2_reg = ctx->regs[def][2];
+	ir_reg tmp_reg = ctx->regs[def][3];
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(type == ctx->ir_base[op1].type && type == ctx->ir_base[op2].type);
+	IR_ASSERT(def_reg != IR_REG_NONE && op1_reg != IR_REG_NONE);
+	if (IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, op1);
+	}
+	if (op2_reg != IR_REG_NONE) {
+		if (IR_REG_SPILLED(op2_reg)) {
+			op2_reg = IR_REG_NUM(op2_reg);
+			if (op1 != op2) {
+				ir_emit_load(ctx, type, op2_reg, op2);
+			}
+		}
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpadd, element_type, width, def_reg, op1_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_OP vaddp, element_type, width, def_reg, op1_reg, op2_reg
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpsub, element_type, width, def_reg, op1_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_OP vsubp, element_type, width, def_reg, op1_reg, op2_reg
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpmullw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpmulld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpmullw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpmulld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_OP vmulp, element_type, width, def_reg, op1_reg, op2_reg
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_AVX_FP_VEC_REG_REG_REG_OP vdivp, element_type, width, def_reg, op1_reg, op2_reg
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	vpminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U8) {
+							|	vpminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16) {
+							|	vpminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U16) {
+							|	vpminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32) {
+							|	vpminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U32) {
+							|	vpminud xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	vpminsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U8) {
+							|	vpminub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16) {
+							|	vpminsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U16) {
+							|	vpminuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32) {
+							|	vpminsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U32) {
+							|	vpminud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_OP vminp, element_type, width, def_reg, op1_reg, op2_reg
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	vpmaxsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U8) {
+							|	vpmaxub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16) {
+							|	vpmaxsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U16) {
+							|	vpmaxuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32) {
+							|	vpmaxsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U32) {
+							|	vpmaxud xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	vpmaxsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U8) {
+							|	vpmaxub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16) {
+							|	vpmaxsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U16) {
+							|	vpmaxuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32) {
+							|	vpmaxsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_U32) {
+							|	vpmaxud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_OP vmaxp, element_type, width, def_reg, op1_reg, op2_reg
+				}
+				break;
+			case IR_AND:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpand xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (width == 32) {
+					|	vpand ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_OR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpor xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (width == 32) {
+					|	vpor ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_XOR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+				} else if (width == 32) {
+					|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_EQ:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpeq, element_type, width, def_reg, op1_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 0
+				}
+				break;
+			case IR_NE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					IR_ASSERT(tmp_reg != IR_REG_NONE);
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpeq, element_type, width, def_reg, op1_reg, op2_reg
+					if (width == 16) {
+						|	vpxor xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST)
+					} else if (width == 32) {
+						|	vpxor ymm(tmp_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpeq, element_type, width, def_reg, def_reg, tmp_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 4
+				}
+				break;
+			case IR_LT:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpgt, element_type, width, def_reg, op2_reg, op1_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 1
+				}
+				break;
+			case IR_GT:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpgt, element_type, width, def_reg, op1_reg, op2_reg
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op2_reg, op1_reg, 1
+				}
+				break;
+			case IR_LE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32|| element_type == IR_U32) {
+							|	vpminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I64 || element_type == IR_U64) {
+							|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+							|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpminsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I64 || element_type == IR_U64) {
+							|	vpcmpgtq ymm(tmp_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+							|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqq ymm(def_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 2
+				}
+				break;
+			case IR_GE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32|| element_type == IR_U32) {
+							|	vpminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I64 || element_type == IR_U64) {
+							|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+							|	vpcmpgtq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpminsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I64 || element_type == IR_U64) {
+							|	vpcmpgtq ymm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+							|	vpcmpgtq ymm(def_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op2_reg, op1_reg, 2
+				}
+				break;
+			case IR_ULT:
+				if (IR_IS_TYPE_INT(element_type)) {
+//???					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpgt, element_type, width, def_reg, op2_reg, op1_reg
+					IR_ASSERT(0 && "unsupported vector type");
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op2_reg, op1_reg, 6
+				}
+				break;
+			case IR_UGT:
+				if (IR_IS_TYPE_INT(element_type)) {
+//???					|	ASM_AVX_INT_VEC_REG_REG_REG_OP vpcmpgt, element_type, width, def_reg, op1_reg, op2_reg
+					IR_ASSERT(0 && "unsupported vector type");
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 6
+				}
+				break;
+			case IR_ULE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32|| element_type == IR_U32) {
+							|	vpminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+//???					} else if (element_type == IR_I64 || element_type == IR_U64) {
+//							|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+//							|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+//							|	vpcmpgtq xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpminud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+//???					} else if (element_type == IR_I64 || element_type == IR_U64) {
+//							|	vpcmpgtq ymm(tmp_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+//							|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+//							|	vpcmpgtq ymm(def_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op2_reg, op1_reg, 5
+				}
+				break;
+			case IR_UGE:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32|| element_type == IR_U32) {
+							|	vpminud xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+//???					} else if (element_type == IR_I64 || element_type == IR_U64) {
+//							|	vpcmpgtq xmm(tmp_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+//							|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+//							|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(tmp_reg-IR_REG_FP_FIRST), xmm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8 || element_type == IR_U8) {
+							|	vpminub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqb ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpminuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqw ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpminud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+							|	vpcmpeqd ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+//???					} else if (element_type == IR_I64 || element_type == IR_U64) {
+//							|	vpcmpgtq ymm(tmp_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+//							|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+//							|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(tmp_reg-IR_REG_FP_FIRST), ymm(def_reg-IR_REG_FP_FIRST)
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 5
+				}
+				break;
+			case IR_ORDERED:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 7
+				break;
+			case IR_UNORDERED:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_AVX_FP_VEC_REG_REG_REG_TXT_OP vcmpp, element_type, width, def_reg, op1_reg, op2_reg, 3
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	vpsllw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpslld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpsllq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	vpsllw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpslld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpsllq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16) {
+						|	vpsraw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U16) {
+						|	vpsrlw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32) {
+						|	vpsrad xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U32) {
+						|	vpsrld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U64) {
+						|	vpsrlq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), xmm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16) {
+						|	vpsraw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U16) {
+						|	vpsrlw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_I32) {
+						|	vpsrad ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U32) {
+						|	vpsrld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else if (element_type == IR_U64) {
+						|	vpsrlq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), ymm(op2_reg-IR_REG_FP_FIRST)
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+		}
+	} else if (IR_IS_CONST_REF(op2)) {
+		int label = ir_get_const_label(ctx, op2);
+
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_TXT_OP vpadd, element_type, width, def_reg, op1_reg, [=>label]
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vaddp, element_type, width, def_reg, op1_reg, [=>label]
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_TXT_OP vpsub, element_type, width, def_reg, op1_reg, [=>label]
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vsubp, element_type, width, def_reg, op1_reg, [=>label]
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpmullw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpmulld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	vpmullw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	vpmulld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vmulp, element_type, width, def_reg, op1_reg, [=>label]
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vdivp, element_type, width, def_reg, op1_reg, [=>label]
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	vpminsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U8) {
+							|	vpminub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I16) {
+							|	vpminsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U16) {
+							|	vpminuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32) {
+							|	vpminsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U32) {
+							|	vpminud xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	vpminsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U8) {
+							|	vpminub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I16) {
+							|	vpminsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U16) {
+							|	vpminuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32) {
+							|	vpminsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U32) {
+							|	vpminud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vminp, element_type, width, def_reg, op1_reg, [=>label]
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	vpmaxsb xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U8) {
+							|	vpmaxub xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I16) {
+							|	vpmaxsw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U16) {
+							|	vpmaxuw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32) {
+							|	vpmaxsd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U32) {
+							|	vpmaxud xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	vpmaxsb ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U8) {
+							|	vpmaxub ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I16) {
+							|	vpmaxsw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U16) {
+							|	vpmaxuw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_I32) {
+							|	vpmaxsd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else if (element_type == IR_U32) {
+							|	vpmaxud ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_TXT_OP vmaxp, element_type, width, def_reg, op1_reg, [=>label]
+				}
+				break;
+			case IR_AND:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpand xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (width == 32) {
+					|	vpand ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_OR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpor xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (width == 32) {
+					|	vpor ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_XOR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					|	vpxor xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else if (width == 32) {
+					|	vpxor ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	vpsllw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpslld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpsllq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	vpsllw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpslld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	vpsllq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16) {
+						|	vpsraw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U16) {
+						|	vpsrlw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32) {
+						|	vpsrad xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U32) {
+						|	vpsrld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U64) {
+						|	vpsrlq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16) {
+						|	vpsraw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U16) {
+						|	vpsrlw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_I32) {
+						|	vpsrad ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U32) {
+						|	vpsrld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else if (element_type == IR_U64) {
+						|	vpsrlq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), [=>label]
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+		}
+	} else {
+		ir_mem mem;
+
+		if (ir_rule(ctx, op2) & IR_FUSED) {
+			mem = ir_fuse_load(ctx, def, op2);
+		} else {
+			mem = ir_ref_spill_slot(ctx, op2);
+		}
+		switch (insn->op) {
+			default:
+				IR_ASSERT(0 && "NIY binary op");
+			case IR_ADD:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_MEM_OP vpadd, element_type, width, def_reg, op1_reg, mem
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vaddp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_SUB:
+				if (IR_IS_TYPE_INT(element_type)) {
+					|	ASM_AVX_INT_VEC_REG_REG_MEM_OP vpsub, element_type, width, def_reg, op1_reg, mem
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vsubp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_MUL:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmullw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmulld, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I16 || element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmullw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_I32 || element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmulld, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vmulp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_DIV:
+				IR_ASSERT(IR_IS_TYPE_FP(element_type));
+				|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vdivp, element_type, width, def_reg, op1_reg, mem
+				break;
+			case IR_MIN:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsb, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U8) {
+							|	ASM_TXT_TXT_TMEM_OP vpminub, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_I16) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpminuw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_I32) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsd, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpminud, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsb, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U8) {
+							|	ASM_TXT_TXT_TMEM_OP vpminub, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_I16) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpminuw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_I32) {
+							|	ASM_TXT_TXT_TMEM_OP vpminsd, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpminud, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vminp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_MAX:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						if (element_type == IR_I8) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsb, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U8) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxub, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_I16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxuw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_I32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsd, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else if (element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxud, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else if (width == 32) {
+						if (element_type == IR_I8) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsb, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U8) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxub, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_I16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U16) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxuw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_I32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxsd, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else if (element_type == IR_U32) {
+							|	ASM_TXT_TXT_TMEM_OP vpmaxud, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+						} else {
+							IR_ASSERT(0 && "unsupported vector type");
+						}
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vmaxp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_AND:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						|	ASM_TXT_TXT_TMEM_OP vpand, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (width == 32) {
+						|	ASM_TXT_TXT_TMEM_OP vpand, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vandp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_OR:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						|	ASM_TXT_TXT_TMEM_OP vpor, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (width == 32) {
+						|	ASM_TXT_TXT_TMEM_OP vpor, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vorp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_XOR:
+				if (IR_IS_TYPE_INT(element_type)) {
+					if (width == 16) {
+						|	ASM_TXT_TXT_TMEM_OP vpxor, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (width == 32) {
+						|	ASM_TXT_TXT_TMEM_OP vpxor, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector width");
+					}
+				} else {
+					IR_ASSERT(IR_IS_TYPE_FP(element_type));
+					|	ASM_AVX_FP_VEC_REG_REG_MEM_OP vxorp, element_type, width, def_reg, op1_reg, mem
+				}
+				break;
+			case IR_SHL:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsllw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpslld, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsllq, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16 || element_type == IR_U16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsllw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpslld, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_I32 || element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsllq, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+			case IR_SHR:
+				IR_ASSERT(IR_IS_TYPE_INT(element_type));
+				if (width == 16) {
+					if (element_type == IR_I16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsraw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrlw, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_I32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrad, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrld, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else if (element_type == IR_U64) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrlq, xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else if (width == 32) {
+					if (element_type == IR_I16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsraw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_U16) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrlw, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_I32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrad, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_U32) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrld, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else if (element_type == IR_U64) {
+						|	ASM_TXT_TXT_TMEM_OP vpsrlq, ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), yword, mem
+					} else {
+						IR_ASSERT(0 && "unsupported vector type");
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+				break;
+		}
+	}
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_shift_sse2(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	ir_ref op1 = insn->op1;
+	ir_ref op2 = insn->op2;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+	int shift;
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+
+	IR_ASSERT(IR_VECTOR_SIZE(type) == 16);
+	IR_ASSERT(type == ctx->ir_base[op1].type && type == ctx->ir_base[op2].type);
+	IR_ASSERT(def_reg != IR_REG_NONE);
+
+	if (op1_reg != IR_REG_NONE && IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, op1);
+	}
+	if (def_reg != op1_reg) {
+		if (op1_reg != IR_REG_NONE) {
+			ir_emit_fp_mov(ctx, type, def_reg, op1_reg);
+		} else {
+			ir_emit_load(ctx, type, def_reg, op1);
+		}
+	}
+
+	IR_ASSERT(IR_IS_CONST_REF(op2) && IR_IS_TYPE_INT(ctx->ir_base[op2].type));
+	shift = ctx->ir_base[op2].val.i32;
+
+	switch (insn->op) {
+		default:
+			IR_ASSERT(0 && "NIY binary op");
+		case IR_SHL:
+			IR_ASSERT(IR_IS_TYPE_INT(element_type));
+			if (element_type == IR_I16 || element_type == IR_U16) {
+				|	psllw xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_I32 || element_type == IR_U32) {
+				|	pslld xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_I32 || element_type == IR_U32) {
+				|	psllq xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else {
+				IR_ASSERT(0 && "unsupported vector type");
+			}
+			break;
+		case IR_SHR:
+			IR_ASSERT(IR_IS_TYPE_INT(element_type));
+			if (element_type == IR_I16) {
+				|	psraw xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_U16) {
+				|	psrlw xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_I32) {
+				|	psrad xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_U32) {
+				|	psrld xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else if (element_type == IR_U64) {
+				|	psrlq xmm(def_reg-IR_REG_FP_FIRST), shift
+			} else {
+				IR_ASSERT(0 && "unsupported vector type");
+			}
+			break;
+	}
+
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_shift_avx(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type type = insn->type;
+	ir_type element_type;
+	uint32_t width;
+	ir_ref op1 = insn->op1;
+	ir_ref op2 = insn->op2;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+	int shift;
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(type));
+	element_type = IR_VECTOR_BASE_TYPE(type);
+	width = IR_VECTOR_SIZE(type);
+
+	IR_ASSERT(type == ctx->ir_base[op1].type && type == ctx->ir_base[op2].type);
+	IR_ASSERT(def_reg != IR_REG_NONE && op1_reg != IR_REG_NONE);
+	if (IR_REG_SPILLED(op1_reg)) {
+		op1_reg = IR_REG_NUM(op1_reg);
+		ir_emit_load(ctx, type, op1_reg, op1);
+	}
+
+	IR_ASSERT(IR_IS_CONST_REF(op2) && IR_IS_TYPE_INT(ctx->ir_base[op2].type));
+	shift = ctx->ir_base[op2].val.i32;
+
+	switch (insn->op) {
+		default:
+			IR_ASSERT(0 && "NIY binary op");
+		case IR_SHL:
+			IR_ASSERT(IR_IS_TYPE_INT(element_type));
+			if (width == 16) {
+				if (element_type == IR_I16 || element_type == IR_U16) {
+					|	vpsllw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	vpslld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	vpsllq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+			} else if (width == 32) {
+				if (element_type == IR_I16 || element_type == IR_U16) {
+					|	vpsllw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	vpslld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32 || element_type == IR_U32) {
+					|	vpsllq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+			} else {
+				IR_ASSERT(0 && "unsupported vector width");
+			}
+			break;
+		case IR_SHR:
+			IR_ASSERT(IR_IS_TYPE_INT(element_type));
+			if (width == 16) {
+				if (element_type == IR_I16) {
+					|	vpsraw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U16) {
+					|	vpsrlw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32) {
+					|	vpsrad xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U32) {
+					|	vpsrld xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U64) {
+					|	vpsrlq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST), shift
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+			} else if (width == 32) {
+				if (element_type == IR_I16) {
+					|	vpsraw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U16) {
+					|	vpsrlw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_I32) {
+					|	vpsrad ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U32) {
+					|	vpsrld ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else if (element_type == IR_U64) {
+					|	vpsrlq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST), shift
+				} else {
+					IR_ASSERT(0 && "unsupported vector type");
+				}
+			} else {
+				IR_ASSERT(0 && "unsupported vector width");
+			}
+			break;
+	}
+	if (IR_REG_SPILLED(ctx->regs[def][0])) {
+		ir_emit_store(ctx, insn->type, def, def_reg);
+	}
+}
+
+static void ir_emit_vector_ext(ir_ctx *ctx, ir_ref def, ir_insn *insn)
+{
+	ir_backend_data *data = ctx->data;
+	dasm_State **Dst = &data->dasm_state;
+	ir_type dst_type = insn->type;
+	ir_type src_type = ctx->ir_base[insn->op1].type;
+	ir_type dst_element_type, src_element_type;
+	uint32_t width, src_size, dst_size;
+	ir_reg def_reg = IR_REG_NUM(ctx->regs[def][0]);
+	ir_reg op1_reg = ctx->regs[def][1];
+
+	IR_ASSERT(IR_IS_TYPE_VECTOR(src_type) && IR_IS_TYPE_VECTOR(dst_type));
+	src_element_type = IR_VECTOR_BASE_TYPE(src_type);
+	width = IR_VECTOR_SIZE(src_type);
+	dst_element_type = IR_VECTOR_BASE_TYPE(dst_type);
+	IR_ASSERT(width == (uint32_t)IR_VECTOR_SIZE(dst_type));
+
+	IR_ASSERT(IR_IS_TYPE_INT(src_element_type));
+	IR_ASSERT(IR_IS_TYPE_INT(dst_element_type));
+	src_size = ir_type_size[src_element_type];
+	dst_size = ir_type_size[dst_element_type];
+	IR_ASSERT(src_size > dst_size);
+	IR_ASSERT(def_reg != IR_REG_NONE);
+
+	if (op1_reg != IR_REG_NONE) {
+		if (IR_REG_SPILLED(op1_reg)) {
+			op1_reg = IR_REG_NUM(op1_reg);
+			ir_emit_load(ctx, src_type, op1_reg, insn->op1);
+		}
+		if (src_size == 1) {
+			if (dst_size == 2) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	pmovzxbw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	pmovsxbw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbw xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbw ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else if (dst_size == 4) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	pmovzxbd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	pmovsxbd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else {
+				IR_ASSERT(dst_size == 8);
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	pmovzxbq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	pmovsxbq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxbq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxbq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			}
+		} else if (src_size == 2) {
+			if (dst_size == 4) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	pmovzxwd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	pmovsxwd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxwd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxwd xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxwd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxwd ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else {
+				IR_ASSERT(dst_size == 8);
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	pmovzxwq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	pmovsxwq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxwq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxwq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	vpmovzxwq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					} else {
+						|	vpmovsxwq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			}
+		} else {
+			IR_ASSERT(src_size == 4);
+			IR_ASSERT(dst_size == 8);
+			if (!(ctx->mflags & IR_X86_AVX2)) {
+				IR_ASSERT(width == 16);
+				if (insn->op == IR_ZEXT) {
+					|	pmovzxdq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				} else {
+					|	pmovsxdq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				}
+			} else if (width == 16) {
+				if (insn->op == IR_ZEXT) {
+					|	vpmovzxdq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				} else {
+					|	vpmovsxdq xmm(def_reg-IR_REG_FP_FIRST), xmm(op1_reg-IR_REG_FP_FIRST)
+				}
+			} else if (width == 32) {
+				if (insn->op == IR_ZEXT) {
+					|	vpmovzxdq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+				} else {
+					|	vpmovsxdq ymm(def_reg-IR_REG_FP_FIRST), ymm(op1_reg-IR_REG_FP_FIRST)
+				}
+			} else {
+				IR_ASSERT(0 && "unsupported vector width");
+			}
+		}
+	} else if (IR_IS_CONST_REF(insn->op1)) {
+		IR_ASSERT(0);
+	} else {
+		ir_mem mem;
+
+		if (ir_rule(ctx, insn->op1) & IR_FUSED) {
+			mem = ir_fuse_load(ctx, def, insn->op1);
+		} else {
+			mem = ir_ref_spill_slot(ctx, insn->op1);
+		}
+
+		if (src_size == 1) {
+			if (dst_size == 2) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP pmovzxbw, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP pmovsxbw, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbw, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbw, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbw, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbw, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else if (dst_size == 4) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP pmovzxbd, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP pmovsxbd, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbd, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbd, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbd, ymm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbd, ymm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else {
+				IR_ASSERT(dst_size == 8);
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP pmovzxbq, xmm(def_reg-IR_REG_FP_FIRST), word, mem
+					} else {
+						|	ASM_TXT_TMEM_OP pmovsxbq, xmm(def_reg-IR_REG_FP_FIRST), word, mem
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbq, xmm(def_reg-IR_REG_FP_FIRST), word, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbq, xmm(def_reg-IR_REG_FP_FIRST), word, mem
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxbq, ymm(def_reg-IR_REG_FP_FIRST), dword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxbq, ymm(def_reg-IR_REG_FP_FIRST), dword, mem
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			}
+		} else if (src_size == 2) {
+			if (dst_size == 4) {
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP pmovzxwd, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP pmovsxwd, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxwd, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxwd, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxwd, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxwd, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			} else {
+				IR_ASSERT(dst_size == 8);
+				if (!(ctx->mflags & IR_X86_AVX2)) {
+					IR_ASSERT(width == 16);
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP pmovzxwq, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP pmovsxwq, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					}
+				} else if (width == 16) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxwq, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxwq, xmm(def_reg-IR_REG_FP_FIRST), dword, mem
+					}
+				} else if (width == 32) {
+					if (insn->op == IR_ZEXT) {
+						|	ASM_TXT_TMEM_OP vpmovzxwq, ymm(def_reg-IR_REG_FP_FIRST), qword, mem
+					} else {
+						|	ASM_TXT_TMEM_OP vpmovsxwq, ymm(def_reg-IR_REG_FP_FIRST), qword, mem
+					}
+				} else {
+					IR_ASSERT(0 && "unsupported vector width");
+				}
+			}
+		} else {
+			IR_ASSERT(src_size == 4);
+			IR_ASSERT(dst_size == 8);
+			if (!(ctx->mflags & IR_X86_AVX2)) {
+				IR_ASSERT(width == 16);
+				if (insn->op == IR_ZEXT) {
+					|	ASM_TXT_TMEM_OP pmovzxdq, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+				} else {
+					|	ASM_TXT_TMEM_OP pmovsxdq, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+				}
+			} else if (width == 16) {
+				if (insn->op == IR_ZEXT) {
+					|	ASM_TXT_TMEM_OP vpmovzxdq, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+				} else {
+					|	ASM_TXT_TMEM_OP vpmovsxdq, xmm(def_reg-IR_REG_FP_FIRST), qword, mem
+				}
+			} else if (width == 32) {
+				if (insn->op == IR_ZEXT) {
+					|	ASM_TXT_TMEM_OP vpmovzxdq, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+				} else {
+					|	ASM_TXT_TMEM_OP vpmovsxdq, ymm(def_reg-IR_REG_FP_FIRST), oword, mem
+				}
+			} else {
+				IR_ASSERT(0 && "unsupported vector width");
+			}
+		}
+	}
+}
+#endif
+
 static void ir_emit_exitcall(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 {
 	ir_backend_data *data = ctx->data;
@@ -16659,6 +19874,35 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 				case IR_TRAP:
 					|	int3
 					break;
+#if IR_SIMD
+				case IR_EXTRACT:
+					ir_emit_vector_extract(ctx, i, insn);
+					break;
+				case IR_REPLACE:
+					ir_emit_vector_replace(ctx, i, insn);
+					break;
+				case IR_SPLAT:
+					ir_emit_vector_splat(ctx, i, insn);
+					break;
+				case IR_VECTOR_OP:
+					ir_emit_vector_op(ctx, i, insn);
+					break;
+				case IR_VECTOR_BINOP_SSE2:
+					ir_emit_vector_binop_sse2(ctx, i, insn);
+					break;
+				case IR_VECTOR_BINOP_AVX:
+					ir_emit_vector_binop_avx(ctx, i, insn);
+					break;
+				case IR_VECTOR_SHIFT_SSE2:
+					ir_emit_vector_shift_sse2(ctx, i, insn);
+					break;
+				case IR_VECTOR_SHIFT_AVX:
+					ir_emit_vector_shift_avx(ctx, i, insn);
+					break;
+				case IR_VECTOR_EXT:
+					ir_emit_vector_ext(ctx, i, insn);
+					break;
+#endif
 #if IR_X86_I64
 				case IR_CMP_I64:
 					ir_emit_cmp_i64(ctx, i, insn);

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -1874,7 +1874,7 @@ op2_const:
 				if (IR_IS_TYPE_INT(insn->type)) {
 					constraints->def_reg = cc->int_ret_reg;
 				} else {
-					IR_ASSERT(IR_IS_TYPE_FP(insn->type));
+					IR_ASSERT(IR_IS_TYPE_FP(insn->type) || IR_IS_TYPE_VECTOR(insn->type));
 #ifdef IR_TARGET_X86
 					if (cc->fp_ret_reg == IR_REG_NONE) {
 						ctx->flags2 |= IR_HAS_FP_RET_SLOT;
@@ -2309,6 +2309,24 @@ get_arg_hints:
 			constraints->hints[1] = IR_REG_NONE;
 			constraints->hints[2] = IR_REG_I64_PAIR(IR_REG_RAX, IR_REG_RDX);
 			constraints->hints_count = 3;
+			break;
+#endif
+#if IR_SIMD
+		case IR_SPLAT:
+			flags = IR_USE_MUST_BE_IN_REG | IR_OP1_MUST_BE_IN_REG;
+			insn = &ctx->ir_base[ref];
+			if (IR_IS_CONST_REF(insn->op1)) {
+				constraints->tmp_regs[0] = IR_TMP_REG(1, ctx->ir_base[insn->op1].type, IR_LOAD_SUB_REF, IR_DEF_SUB_REF);
+				n = 1;
+			}
+			break;
+		case IR_REPLACE:
+			flags = IR_DEF_REUSES_OP1_REG | IR_USE_MUST_BE_IN_REG | IR_OP1_MUST_BE_IN_REG | IR_OP2_MUST_BE_IN_REG | IR_OP3_MUST_BE_IN_REG;
+			insn = &ctx->ir_base[ref];
+			if (IR_IS_CONST_REF(insn->op3)) {
+				constraints->tmp_regs[0] = IR_TMP_REG(3, ctx->ir_base[insn->op3].type, IR_LOAD_SUB_REF, IR_DEF_SUB_REF);
+				n = 1;
+			}
 			break;
 #endif
 	}
@@ -11823,7 +11841,7 @@ static void ir_emit_call_ex(ir_ctx *ctx, ir_ref def, ir_insn *insn, const ir_pro
 				ir_emit_store(ctx, insn->type, def, cc->int_ret_reg);
 			}
 		} else {
-			IR_ASSERT(IR_IS_TYPE_FP(insn->type));
+			IR_ASSERT(IR_IS_TYPE_FP(insn->type) || IR_IS_TYPE_VECTOR(insn->type));
 			def_reg = IR_REG_NUM(ctx->regs[def][0]);
 			if (cc->fp_ret_reg != IR_REG_NONE) {
 				if (def_reg != IR_REG_NONE) {
@@ -16262,7 +16280,7 @@ static void ir_emit_vector_splat(ir_ctx *ctx, ir_ref def, ir_insn *insn)
 	if (op1_reg != IR_REG_NONE) {
 		if (IR_REG_SPILLED(op1_reg)) {
 			op1_reg = IR_REG_NUM(op1_reg);
-			ir_emit_load(ctx, type, op1_reg, insn->op1);
+			ir_emit_load(ctx, element_type, op1_reg, insn->op1);
 		}
 		if (IR_IS_TYPE_INT(element_type)) {
 			if (element_type == IR_I8 || element_type == IR_U8) {


### PR DESCRIPTION
Following up on our earlier discussion about ir_emit_c() support for vector types.

I spent some time verifying the existing vector lowering first: ADD (vector-typed
scalar op), SPLAT, EXTRACT, REPLACE, and vector values merged across an if/else
branch (PHI) all already lower to correct, gcc-compilable C. So the emit-c work
I originally offered to help with turned out to be mostly solid already.

What I did find missing was REDUCE — there was no corresponding opcode at the
IR level at all yet, so this PR adds it:

- New opcodes: `IR_REDUCE_ADD`, `IR_REDUCE_MUL`, `IR_REDUCE_MIN`, `IR_REDUCE_MAX`
  in `ir.h`, following the existing convention of one opcode per operation kind
  (like EQ/NE/LT/... and ADD_OV/SUB_OV/...) rather than a generic op + kind
  parameter. Each takes a single vector operand (`d1`, same shape as SPLAT but
  the reverse direction: vector -> scalar).
- Builder macros (`ir_REDUCE_ADD` etc.) in `ir_builder.h`.
- `ir_emit_c()` lowering in `ir_emit_c.c`: ADD/MUL unroll into a flat expression
  (`a[0]+a[1]+...+a[N-1]`), MIN/MAX unroll into a ternary comparison chain.

Known limitation: MIN/MAX use plain C comparison, which doesn't implement IEEE
754 NaN semantics for min/max. Happy to tighten this if it matters for your use
case — wanted to get the basic shape right first.

Verified with hand-written `.ir` test cases plus a small C harness using the
corresponding GCC vector_size ABI:
- REDUCE_ADD([1,2,3,4]) = 10 ✓
- REDUCE_MAX([3,7,1,5]) = 7 ✓

Happy to add SHUFFLE/CONVERT next if this direction looks right to you, or
adjust the opcode/codegen design if you had something different in mind.