### PR TITLE
Replace `cmp + b.ne` with `cbnz`

### DIFF
--- a/ir_aarch64.dasc
+++ b/ir_aarch64.dasc
@@ -3493,8 +3493,7 @@ static void ir_emit_if_int(ir_ctx *ctx, uint32_t b, ir_ref def, ir_insn *insn, u
 		op2_reg = IR_REG_NUM(op2_reg);
 		ir_emit_load(ctx, type, op2_reg, insn->op2);
 	}
-	|	ASM_REG_IMM_OP cmp, type, op2_reg, 0
-	ir_emit_jcc(ctx, b, def, insn, next_block, IR_NE, 1);
+	ir_emit_jz(ctx, b, next_block, IR_NE, type, op2_reg);
 }
 
 static void ir_emit_cond(ir_ctx *ctx, ir_ref def, ir_insn *insn)

--- a/tests/aarch64/if_001.irt
+++ b/tests/aarch64/if_001.irt
@@ -21,8 +21,7 @@ aarch64
 }
 --EXPECT--
 test:
-	cmp w0, #0
-	b.eq .L1
+	cbz w0, .L1
 	mov w0, wzr
 	b .L2
 .L1:

--- a/tests/aarch64/tailcall_002.irt
+++ b/tests/aarch64/tailcall_002.irt
@@ -22,8 +22,7 @@ test:
 	sub sp, sp, #0x10
 	str x0, [sp]
 	add x0, x0, x0
-	cmp x0, #0
-	b.eq .L1
+	cbz x0, .L1
 	ldr x17, [sp]
 	add sp, sp, #0x10
 	br x17

--- a/tests/aarch64/tailcall_003.irt
+++ b/tests/aarch64/tailcall_003.irt
@@ -24,8 +24,7 @@ test:
 	mov x19, x0
 	str x19, [sp]
 	add x19, x19, x19
-	cmp x19, #0
-	b.eq .L1
+	cbz x19, .L1
 	ldr x17, [sp]
 	ldr x19, [sp, #8]
 	add sp, sp, #0x10

--- a/tests/debug.aarch64/combo_001.irt
+++ b/tests/debug.aarch64/combo_001.irt
@@ -37,7 +37,6 @@ aarch64
 --EXPECT--
 test:
 .L1:
-	cmp w0, #0
-	b.ne .L1
+	cbnz w0, .L1
 	movz w0, #0x1
 	ret

--- a/tests/debug.aarch64/combo_002.irt
+++ b/tests/debug.aarch64/combo_002.irt
@@ -49,7 +49,6 @@ aarch64
 --EXPECT--
 test:
 .L1:
-	cmp w0, #0
-	b.ne .L1
+	cbnz w0, .L1
 	movz w0, #0x1
 	ret

--- a/tests/debug.aarch64/combo_003.irt
+++ b/tests/debug.aarch64/combo_003.irt
@@ -49,7 +49,6 @@ aarch64
 --EXPECT--
 test:
 .L1:
-	cmp w0, #0
-	b.ne .L1
+	cbnz w0, .L1
 	mov w0, w1
 	ret

--- a/tests/debug.aarch64/combo_004.irt
+++ b/tests/debug.aarch64/combo_004.irt
@@ -39,7 +39,6 @@ aarch64
 --EXPECT--
 test:
 .L1:
-	cmp w0, #0
-	b.ne .L1
+	cbnz w0, .L1
 	add w0, w1, w1
 	ret

--- a/tests/debug.aarch64/dessa_001.irt
+++ b/tests/debug.aarch64/dessa_001.irt
@@ -25,8 +25,7 @@ aarch64
 }
 --EXPECT--
 test:
-	cmp w2, #0
-	b.eq .L1
+	cbz w2, .L1
 	mov w0, w1
 .L1:
 	ret

--- a/tests/debug.aarch64/dessa_002.irt
+++ b/tests/debug.aarch64/dessa_002.irt
@@ -30,6 +30,5 @@ test:
 	mov w0, w1
 .L2:
 	add w1, w0, #1
-	cmp w1, #0
-	b.ne .L1
+	cbnz w1, .L1
 	ret

--- a/tests/debug.aarch64/dessa_003.irt
+++ b/tests/debug.aarch64/dessa_003.irt
@@ -41,6 +41,5 @@ test:
 	mov w0, w1
 	mov w1, w3
 .L2:
-	cmp w2, #0
-	b.ne .L1
+	cbnz w2, .L1
 	ret

--- a/tests/debug.aarch64/fig-O0.irt
+++ b/tests/debug.aarch64/fig-O0.irt
@@ -86,8 +86,7 @@ test:
 	str w0, [sp, #0x2c]
 .L1:
 	ldr w0, [sp, #0x90]
-	cmp w0, #0
-	b.eq .L2
+	cbz w0, .L2
 	ldr w1, [sp, #8]
 	ldr w2, [sp, #4]
 	mul w0, w1, w2
@@ -145,8 +144,7 @@ test:
 	add w0, w1, #1
 	str w0, [sp, #0x68]
 	ldr w0, [sp, #0x98]
-	cmp w0, #0
-	b.eq .L4
+	cbz w0, .L4
 	ldr w0, [sp, #0x4c]
 	str w0, [sp, #0x1c]
 	ldr w0, [sp, #0x50]

--- a/tests/debug.aarch64/fig.irt
+++ b/tests/debug.aarch64/fig.irt
@@ -77,11 +77,9 @@ test:
 	add w7, w6, #1
 	mov w3, w2
 .L2:
-	cmp w8, #0
-	b.eq .L4
+	cbz w8, .L4
 .L3:
-	cmp w4, #0
-	b.eq .L1
+	cbz w4, .L1
 	mov w5, w10
 	mov w0, w2
 	b .L2

--- a/tests/debug.aarch64/sccp_002.irt
+++ b/tests/debug.aarch64/sccp_002.irt
@@ -70,8 +70,7 @@ test:
 	ret
 	nop
 .L5:
-	cmp w1, #0
-	b.ne .L5
+	cbnz w1, .L5
 	movz w0, #0x1
 	ret
 .rodata


### PR DESCRIPTION
ir_emit_if_int used to emit 
```asm
cmp   w1, #0
b.ne  >refcount_path
```

and now emits 
```asm
cbnz  w1, >refcount_path
```