### PR TITLE
Fix ir_emit_c() crash on LOAD with unused result

### DIFF
--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -759,7 +759,11 @@ static void ir_emit_vstore(ir_ctx *ctx, FILE *f, ir_insn *insn)
 
 static void ir_emit_load(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
-	ir_emit_def_ref(ctx, f, def);
+	if (ctx->vregs[def]) {
+		ir_emit_def_ref(ctx, f, def);
+	} else {
+		fprintf(f, "\t");
+	}
 	fprintf(f, "*((%s*)", ir_type_cname[insn->type]);
 	if (IR_IS_CONST_REF(insn->op2)) {
 		ir_emit_c_const(ctx, &ctx->ir_base[insn->op2], f);

--- a/tests/c/load_001.irt
+++ b/tests/c/load_001.irt
@@ -1,0 +1,18 @@
+--TEST--
+001: LOAD with unused result (-O0)
+--ARGS--
+-O0 --emit-c
+--CODE--
+{
+	l_1 = START(l_4);
+	uintptr_t d_2 = PARAM(l_1, "a", 0);
+	int32_t d_3, l_3 = LOAD(l_1, d_2);
+	l_4 = RETURN(l_3);
+}
+--EXPECT--
+void test(uintptr_t a)
+{
+	uintptr_t d_1 = a;
+	*((int32_t*)d_1);
+	return;
+}


### PR DESCRIPTION
ir_emit_load() called ir_emit_def_ref() unconditionally, which asserts ctx->vregs[def] is set. A LOAD with no data users still keeps vregs[def] at 0, so the assert fires. Guard it like `ir_emit_call()` already does for CALL.