### PR TITLE
Fix ir_emit_c() crash on ALLOCA with unused result

### DIFF
--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -726,7 +726,11 @@ static void ir_emit_ijmp(ir_ctx *ctx, FILE *f, ir_insn *insn)
 
 static void ir_emit_alloca(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
-	ir_emit_def_ref(ctx, f, def);
+	if (ctx->vregs[def]) {
+		ir_emit_def_ref(ctx, f, def);
+	} else {
+		fprintf(f, "\t");
+	}
 	fprintf(f, "(uintptr_t)alloca(");
 	ir_emit_ref(ctx, f, insn->op2);
 	fprintf(f, ");\n");

--- a/tests/c/alloca_004.irt
+++ b/tests/c/alloca_004.irt
@@ -1,0 +1,17 @@
+--TEST--
+004: alloca with unused result
+--ARGS--
+-O0 --emit-c
+--CODE--
+{
+	int32_t size = 10;
+	l_1 = START(l_4);
+	uintptr_t ret, l_2 = ALLOCA(l_1, size);
+	l_4 = RETURN(l_2);
+}
+--EXPECT--
+void test(void)
+{
+	(uintptr_t)alloca(10);
+	return;
+}


### PR DESCRIPTION
Same class of bug as the LOAD fix: ir_emit_alloca() called ir_emit_def_ref() unconditionally, which asserts ctx->vregs[def] is set. ALLOCA is MEM-flagged, not DATA-flagged, so an alloca whose pointer has no data users keeps vregs[def] at 0.