### PR TITLE
Fix vaarg_006/007/008/009 tests: prototype doesn't match actual parameters

### DIFF
--- a/ir.c
+++ b/ir.c
@@ -506,6 +506,7 @@ void ir_init(ir_ctx *ctx, uint32_t flags, ir_ref consts_limit, ir_ref insns_limi
 
 	ctx->spill_base = -1;
 	ctx->fixed_stack_frame_size = -1;
+	ctx->params_count = (uint32_t)-1;
 
 	buf = ir_mem_malloc((consts_limit + insns_limit) * sizeof(ir_insn));
 	ctx->ir_base = buf + consts_limit;

--- a/ir.g
+++ b/ir.g
@@ -385,6 +385,19 @@ ir(ir_loader *loader):
 					{ctx.flags |= flags;}
 					{ctx.ret_type = ret_type;}
 					ir_func(&p)
+					{
+						uint32_t real_params_count = 0;
+						ir_ref r = 2;
+
+						while (ctx.ir_base[r].op == IR_PARAM) {
+							real_params_count++;
+							r++;
+						}
+						if (real_params_count != params_count) {
+							ir_free(&ctx);
+							yy_error_str("parameter count doesn't match function signature", name);
+						}
+					}
 					{bool ok = loader->func_process(loader, &ctx, name);}
 					{ir_free(&ctx);}
 					{if (!ok) yy_error("process_func error");}

--- a/ir.g
+++ b/ir.g
@@ -384,16 +384,10 @@ ir(ir_loader *loader):
 					{if (!loader->func_init(loader, &ctx, name)) yy_error("init_func error");}
 					{ctx.flags |= flags;}
 					{ctx.ret_type = ret_type;}
+					{ctx.params_count = params_count;}
 					ir_func(&p)
 					{
-						uint32_t real_params_count = 0;
-						ir_ref r = 2;
-
-						while (ctx.ir_base[r].op == IR_PARAM) {
-							real_params_count++;
-							r++;
-						}
-						if (real_params_count != params_count) {
+						if (ir_count_params(&ctx) != params_count) {
 							ir_free(&ctx);
 							yy_error_str("parameter count doesn't match function signature", name);
 						}

--- a/ir.h
+++ b/ir.h
@@ -695,6 +695,7 @@ struct _ir_ctx {
 	uint32_t           flags;                   /* IR context flags (see IR_* defines above) */
 	uint32_t           flags2;                  /* IR context private flags (see IR_* defines in ir_private.h) */
 	ir_type            ret_type;                /* Function return type */
+	uint32_t           params_count;            /* Number of function parameters declared in its prototype ((uint32_t)-1 if unknown) */
 	uint32_t           mflags;                  /* CPU specific flags (see IR_X86_... macros below) */
 	int32_t            status;                  /* non-zero error code (see IR_ERROR_... macros), app may use negative codes */
 	ir_ref             fold_cse_limit;          /* CSE finds identical insns backward from "insn_count" to "fold_cse_limit" */

--- a/ir_check.c
+++ b/ir_check.c
@@ -154,6 +154,16 @@ bool ir_check(const ir_ctx *ctx)
 		ok = 0;
 	}
 
+	if (ctx->params_count != (uint32_t)-1) {
+		uint32_t real_params_count = ir_count_params(ctx);
+
+		if (real_params_count != ctx->params_count) {
+			fprintf(stderr, "PARAM count (%u) doesn't match function prototype (%u)\n",
+				real_params_count, ctx->params_count);
+			ok = 0;
+		}
+	}
+
 	check_ctx.arena = NULL;
 	check_ctx.use_set = NULL;
 	check_ctx.input_set = NULL;

--- a/ir_load.c
+++ b/ir_load.c
@@ -1410,6 +1410,19 @@ _yy_state_13:
 						ctx.flags |= flags;
 						ctx.ret_type = ret_type;
 						sym = parse_ir_func(sym, &p);
+						{
+							uint32_t real_params_count = 0;
+							ir_ref r = 2;
+
+							while (ctx.ir_base[r].op == IR_PARAM) {
+								real_params_count++;
+								r++;
+							}
+							if (real_params_count != params_count) {
+								ir_free(&ctx);
+								yy_error_str("parameter count doesn't match function signature", name);
+							}
+						}
 						bool ok = loader->func_process(loader, &ctx, name);
 						ir_free(&ctx);
 						if (!ok) yy_error("process_func error");

--- a/ir_load.c
+++ b/ir_load.c
@@ -1409,16 +1409,10 @@ _yy_state_13:
 						if (!loader->func_init(loader, &ctx, name)) yy_error("init_func error");
 						ctx.flags |= flags;
 						ctx.ret_type = ret_type;
+						ctx.params_count = params_count;
 						sym = parse_ir_func(sym, &p);
 						{
-							uint32_t real_params_count = 0;
-							ir_ref r = 2;
-
-							while (ctx.ir_base[r].op == IR_PARAM) {
-								real_params_count++;
-								r++;
-							}
-							if (real_params_count != params_count) {
+							if (ir_count_params(&ctx) != params_count) {
 								ir_free(&ctx);
 								yy_error_str("parameter count doesn't match function signature", name);
 							}

--- a/ir_load_llvm.c
+++ b/ir_load_llvm.c
@@ -2009,6 +2009,7 @@ static int llvm2ir_func(ir_ctx *ctx, LLVMValueRef func, LLVMModuleRef module)
 
 	ir_START();
 	params_count = LLVMCountParams(func);
+	ctx->params_count = params_count;
 	for (i = 0; i < params_count; i++) {
 		size_t name_len;
 		const char *name;

--- a/ir_private.h
+++ b/ir_private.h
@@ -1083,6 +1083,18 @@ void ir_use_list_replace_all(ir_ctx *ctx, ir_ref def, ir_ref use, ir_ref new_use
 void ir_use_list_replace_one(ir_ctx *ctx, ir_ref def, ir_ref use, ir_ref new_use);
 bool ir_use_list_add(ir_ctx *ctx, ir_ref def, ir_ref use);
 
+IR_ALWAYS_INLINE uint32_t ir_count_params(const ir_ctx *ctx)
+{
+	uint32_t count = 0;
+	ir_ref r = 2;
+
+	while (r < ctx->insns_count && ctx->ir_base[r].op == IR_PARAM) {
+		count++;
+		r++;
+	}
+	return count;
+}
+
 IR_ALWAYS_INLINE ir_ref ir_next_control(const ir_ctx *ctx, ir_ref ref)
 {
 	ir_use_list *use_list = &ctx->use_lists[ref];

--- a/tests/bugs/param_count_mismatch_001.irt
+++ b/tests/bugs/param_count_mismatch_001.irt
@@ -1,0 +1,14 @@
+--TEST--
+Function body PARAM count must match the declared prototype (Apple aarch64 ABI regression)
+--CODE--
+func foo(int32_t, ...): int32_t
+{
+	l_1 = START(l_4);
+	int32_t d_2 = PARAM(l_1, "a", 1);
+	int32_t d_3 = PARAM(l_1, "b", 2);
+	l_4 = RETURN(l_1, d_2);
+}
+--EXPECT--
+ERROR: parameter count doesn't match function signature 'foo' at line 8
+
+exit code = 2


### PR DESCRIPTION
Fix 4 failing tests for IR for MACOS aarch64.

I'm not sure whether only tests should be fixed, the check should be added (current PR), or the check should be more general.

The exact failures:
https://github.com/dstogov/ir/actions/runs/29170932167/job/86753268624?pr=135#step:5:2317

```
TEST: VA_ARG 006: va_arg(int) [./tests/run/vaarg_006.irt]
--- ./tests/run/vaarg_006.exp	2026-07-13 06:56:55
+++ ./tests/run/vaarg_006.out	2026-07-13 06:56:55
@@ -1 +1 @@
-sum 45
+sum 46

FAIL: VA_ARG 006: va_arg(int) [./tests/run/vaarg_006.irt]
TEST: VA_ARG 007: va_arg(double) [./tests/run/vaarg_007.irt]
--- ./tests/run/vaarg_007.exp	2026-07-13 06:56:55
+++ ./tests/run/vaarg_007.out	2026-07-13 06:56:55
@@ -1 +1 @@
-sum 55
+sum 36

FAIL: VA_ARG 007: va_arg(double) [./tests/run/vaarg_007.irt]
TEST: VA_ARG 008: va_arg(int) [./tests/run/vaarg_008.irt]
--- ./tests/run/vaarg_008.exp	2026-07-13 06:56:56
+++ ./tests/run/vaarg_008.out	2026-07-13 06:56:56
@@ -1 +1 @@
-sum 45
+sum 66

FAIL: VA_ARG 008: va_arg(int) [./tests/run/vaarg_008.irt]
TEST: VA_ARG 009: va_arg(double) [./tests/run/vaarg_009.irt]
--- ./tests/run/vaarg_009.exp	2026-07-13 06:56:56
+++ ./tests/run/vaarg_009.out	2026-07-13 06:56:56
@@ -1 +1 @@
-sum 55
+sum 6

FAIL: VA_ARG 009: va_arg(double) [./tests/run/vaarg_009.irt]
```