### PR TITLE
Add ABI header support to tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ else ifneq (, $(filter aarch64 arm64, $(TARGET)))
   override BUILD_CFLAGS += -DIR_TARGET_AARCH64
   DASM_ARCH  = aarch64
   DASM_FLAGS = -M
-  TEST_TARGET=aarch64
+  ifeq (Darwin, $(OS))
+    TEST_TARGET=aarch64-darwin
+  else
+    TEST_TARGET=aarch64-sysv
+  endif
 else
  $(error Unsupported target. TRGET must be 'x86_64', 'x86' or 'aarch64')
 endif

--- a/tests/run/vaarg_004_aarch64_sysv.irt
+++ b/tests/run/vaarg_004_aarch64_sysv.irt
@@ -1,7 +1,7 @@
 --TEST--
-VA_ARG 004: va_arg() expanded on AArch64
+VA_ARG 004: va_arg() expanded on AArch64 SysV
 --TARGET--
-aarch64
+aarch64-sysv
 --ARGS--
 --run
 --CODE--

--- a/tools/tester.c
+++ b/tools/tester.c
@@ -178,13 +178,31 @@ static test *parse_file(const char *filename, int id)
 	return t;
 }
 
+static int match_target_name(const char *selector, const char *actual)
+{
+	size_t selector_len;
+
+	if (!selector || !actual) {
+		return 0;
+	}
+	if (strcmp(selector, actual) == 0) {
+		return 1;
+	}
+	selector_len = strlen(selector);
+	return strncmp(selector, actual, selector_len) == 0 && actual[selector_len] == '-';
+}
+
 static int skip_test(test *t)
 {
 	if (target && t->target) {
 		if (t->target[0] == '!') {
-			return strcmp(t->target + 1, target) == 0;
+			if (match_target_name(t->target + 1, target)) {
+				return 1;
+			}
 		} else {
-			return strcmp(t->target, target) != 0;
+			if (!match_target_name(t->target, target)) {
+				return 1;
+			}
 		}
 	}
 	return 0;
@@ -523,6 +541,7 @@ static void print_help(const char *exe_name)
 	    "  Run the \"--CODE--\" section of specified test files using <cmd>\n"
 	    "Options:\n"
 	    "  --target <target>        - skip tests that specifies different --TARGET--\n"
+	    "                            (e.g. aarch64 matches aarch64-sysv and aarch64-darwin)\n"
 	    "  --default-args <args>    - default <cmd> arguments (if --ARGS-- is missed)\n"
 	    "  --additional-args <args> - additional <cmd> arguments (always added at the end)\n"
 	    "  --diff-cmd <cmd>         - diff command\n"


### PR DESCRIPTION
Test `vaarg_004_aarch64.ir` currently fails on macOS arm64. I thought about implementation that would allow skipping certain tests that are not designed for Apple ABI.

In general I would like to extend `TEST_TARGET` to include ABI as well, so the tests may be skippable.

If target contains only `aarch64` then it doesn't consider ABI. If it's specificed i.e. aarch64-darwin, it means it's run only on 
macOS arm64.

If such approach is good, I can extend the TEST_TARGET to include other ABI, like windows', etc.


failing test:
```
TEST: VA_ARG 004: va_arg() expanded on AArch64 [./tests/run/vaarg_004_aarch64.irt]sh: line 1: 98433 Segmentation fault: 11  ./ir ./tests/run/vaarg_004_aarch64.ir --run > ./tests/run/vaarg_004_aarch64.out 2>&1
--- ./tests/run/vaarg_004_aarch64.exp	2026-08-21 22:02:01
+++ ./tests/run/vaarg_004_aarch64.out	2026-08-21 22:02:01
@@ -1 +1,2 @@
-sum 45
+
+termsig = 11
FAIL: VA_ARG 004: va_arg() expanded on AArch64 [./tests/run/vaarg_004_aarch64.irt]
```