### PR TITLE
Fix sparse set allocation size overflow

### DIFF
--- a/ir_private.h
+++ b/ir_private.h
@@ -507,9 +507,12 @@ typedef struct _ir_sparse_set {
 
 IR_ALWAYS_INLINE void ir_sparse_set_init(ir_sparse_set *set, uint32_t size)
 {
+	size_t alloc_size = (size_t)size * 2 * sizeof(*set->data);
+
 	set->size = size;
 	set->len = 0;
-	set->data = (uint32_t*)ir_mem_malloc(sizeof(uint32_t) * 2 * size) + size;
+	IR_ASSERT(!size || alloc_size / size == 2 * sizeof(*set->data));
+	set->data = (uint32_t*)ir_mem_malloc(alloc_size) + size;
 #ifdef IR_DEBUG
 	/* initialize sparse part to avoid valgrind warnings */
 	memset(&IR_SPARSE_SET_SPARSE(set, size - 1), 0, size * sizeof(uint32_t));


### PR DESCRIPTION
Fixes an integer-overflow risk when calculating the allocation size for IR sparse sets.

Uses ir_mem_calloc(size, 2 * sizeof(*set->data)) so the allocator performs the checked multiplication, while preserving the existing sparse/dense memory layout.

The issue was detected by static analysis: [BAD_ALLOC_ARITHMETIC ir_private.h:[500:14].log](https://github.com/user-attachments/files/31533111/BAD_ALLOC_ARITHMETIC.ir_private.h.500.14.log)
