### PR TITLE
fix: constant callee c emitter

### DIFF
--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -779,9 +779,34 @@ static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn
 	fprintf(f, "\t}\n");
 }
 
+static void ir_emit_func_ptr_cast(FILE *f, const ir_proto_t *proto, ir_type ret_type)
+{
+	uint32_t i;
+
+	ir_emit_c_type_name(proto ? proto->ret_type : ret_type, f);
+	fprintf(f, " (*)(");
+	if (proto && proto->params_count) {
+		for (i = 0; i < proto->params_count; i++) {
+			if (i) {
+				fprintf(f, ", ");
+			}
+			ir_emit_c_type_name(proto->param_types[i], f);
+		}
+		if (proto->flags & IR_VARARG_FUNC) {
+			fprintf(f, ", ...");
+		}
+	} else if (proto && (proto->flags & IR_VARARG_FUNC)) {
+		fprintf(f, "...");
+	} else {
+		fprintf(f, "void");
+	}
+	fprintf(f, "))");
+}
+
 static void ir_emit_call(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 {
 	int j, n;
+	const ir_proto_t *proto = ir_call_proto(ctx, insn);
 
 	if (insn->type != IR_VOID && ctx->vregs[def] != IR_UNUSED) {
 		ir_emit_def_ref(ctx, f, def);
@@ -789,8 +814,15 @@ static void ir_emit_call(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 		fprintf(f, "\t");
 	}
 	if (IR_IS_CONST_REF(insn->op2)) {
-		IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC);
-		fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
+		if (ctx->ir_base[insn->op2].op == IR_FUNC) {
+			fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
+		} else {
+		    IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
+			fprintf(f, "((");
+			ir_emit_func_ptr_cast(f, proto, insn->type);
+			ir_emit_ref(ctx, f, insn->op2);
+			fprintf(f, ")");
+		}
 	} else {
 		ir_emit_ref(ctx, f, insn->op2);
 	}
@@ -812,6 +844,7 @@ static void ir_emit_call(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 static void ir_emit_tailcall(ir_ctx *ctx, FILE *f, ir_insn *insn)
 {
 	int j, n;
+	const ir_proto_t *proto = ir_call_proto(ctx, insn);
 
 	if (insn->type != IR_VOID) {
 		fprintf(f, "\treturn ");
@@ -819,8 +852,15 @@ static void ir_emit_tailcall(ir_ctx *ctx, FILE *f, ir_insn *insn)
 		fprintf(f, "\t");
 	}
 	if (IR_IS_CONST_REF(insn->op2)) {
-		IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC);
-		fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
+		if (ctx->ir_base[insn->op2].op == IR_FUNC) {
+			fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
+		} else {
+            IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
+			fprintf(f, "((");
+			ir_emit_func_ptr_cast(f, proto, insn->type);
+			ir_emit_ref(ctx, f, insn->op2);
+			fprintf(f, ")");
+		}
 	} else {
 		ir_emit_ref(ctx, f, insn->op2);
 	}

--- a/ir_emit_c.c
+++ b/ir_emit_c.c
@@ -55,6 +55,87 @@ static void ir_emit_c_type_name(ir_type type, FILE *f)
 	}
 }
 
+static bool ir_emit_c_call_conv(FILE *f, uint32_t flags)
+{
+	switch (flags & IR_CALL_CONV_MASK) {
+		case IR_CC_FASTCALL:
+			fprintf(f, "__fastcall");
+			return 1;
+		case IR_CC_PRESERVE_NONE:
+			fprintf(f, "__attribute__((preserve_none))");
+			return 1;
+#if defined(IR_TARGET_X64)
+		case IR_CC_X86_64_SYSV:
+			fprintf(f, "__attribute__((sysv_abi))");
+			return 1;
+		case IR_CC_X86_64_MS:
+			fprintf(f, "__attribute__((ms_abi))");
+			return 1;
+#elif defined(IR_TARGET_AARCH64)
+		case IR_CC_AARCH64_SYSV:
+			return 0;
+		case IR_CC_AARCH64_DARWIN:
+			return 0;
+#endif
+		default:
+			IR_ASSERT((flags & IR_CALL_CONV_MASK) == IR_CC_DEFAULT || (flags & IR_CALL_CONV_MASK) == IR_CC_BUILTIN);
+			return 0;
+	}
+}
+
+static void ir_emit_c_func_params(FILE *f, uint32_t flags, uint32_t params_count, const uint8_t *param_types)
+{
+	uint32_t i;
+
+	if (params_count) {
+		for (i = 0; i < params_count; i++) {
+			if (i) {
+				fprintf(f, ", ");
+			}
+			ir_emit_c_type_name(param_types[i], f);
+		}
+		if (flags & IR_VARARG_FUNC) {
+			fprintf(f, ", ...");
+		}
+	} else if (flags & IR_VARARG_FUNC) {
+		fprintf(f, "...");
+	} else {
+		fprintf(f, "void");
+	}
+}
+
+static void ir_emit_c_func_decl_ex(const char *name, uint32_t flags, ir_type ret_type, uint32_t params_count, const uint8_t *param_types, bool is_ptr, FILE *f)
+{
+	bool has_call_conv;
+
+	ir_emit_c_type_name(ret_type, f);
+	has_call_conv = 0;
+	if (is_ptr) {
+		fprintf(f, " (");
+		has_call_conv = ir_emit_c_call_conv(f, flags);
+		if (has_call_conv) {
+			fprintf(f, " ");
+		}
+		fprintf(f, "*");
+		if (name) {
+			fprintf(f, "%s", name);
+		}
+		fprintf(f, ")");
+	} else {
+		fprintf(f, " ");
+		has_call_conv = ir_emit_c_call_conv(f, flags);
+		if (has_call_conv) {
+			fprintf(f, " ");
+		}
+		if (name) {
+			fprintf(f, "%s", name);
+		}
+	}
+	fprintf(f, "(");
+	ir_emit_c_func_params(f, flags, params_count, param_types);
+	fprintf(f, ")");
+}
+
 static void ir_emit_c_const(ir_ctx *ctx, ir_insn *insn, FILE *f)
 {
 	if (insn->op == IR_LABEL) {
@@ -781,26 +862,21 @@ static void ir_emit_switch(ir_ctx *ctx, FILE *f, uint32_t b, ir_ref def, ir_insn
 
 static void ir_emit_func_ptr_cast(FILE *f, const ir_proto_t *proto, ir_type ret_type)
 {
-	uint32_t i;
+	ir_emit_c_func_decl_ex(NULL,
+		proto ? proto->flags : IR_CC_DEFAULT,
+		proto ? proto->ret_type : ret_type,
+		proto ? proto->params_count : 0,
+		proto ? proto->param_types : NULL,
+		1, f);
+}
 
-	ir_emit_c_type_name(proto ? proto->ret_type : ret_type, f);
-	fprintf(f, " (*)(");
-	if (proto && proto->params_count) {
-		for (i = 0; i < proto->params_count; i++) {
-			if (i) {
-				fprintf(f, ", ");
-			}
-			ir_emit_c_type_name(proto->param_types[i], f);
-		}
-		if (proto->flags & IR_VARARG_FUNC) {
-			fprintf(f, ", ...");
-		}
-	} else if (proto && (proto->flags & IR_VARARG_FUNC)) {
-		fprintf(f, "...");
-	} else {
-		fprintf(f, "void");
-	}
-	fprintf(f, "))");
+static void ir_emit_typed_func_ref(ir_ctx *ctx, FILE *f, ir_ref ref, const ir_proto_t *proto, ir_type ret_type)
+{
+	fprintf(f, "((");
+	ir_emit_func_ptr_cast(f, proto, ret_type);
+	fprintf(f, ")");
+	ir_emit_ref(ctx, f, ref);
+	fprintf(f, ")");
 }
 
 static void ir_emit_call(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
@@ -817,12 +893,11 @@ static void ir_emit_call(ir_ctx *ctx, FILE *f, ir_ref def, ir_insn *insn)
 		if (ctx->ir_base[insn->op2].op == IR_FUNC) {
 			fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
 		} else {
-		    IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
-			fprintf(f, "((");
-			ir_emit_func_ptr_cast(f, proto, insn->type);
-			ir_emit_ref(ctx, f, insn->op2);
-			fprintf(f, ")");
+			IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
+			ir_emit_typed_func_ref(ctx, f, insn->op2, proto, insn->type);
 		}
+	} else if (ctx->ir_base[insn->op2].op == IR_PROTO) {
+		ir_emit_typed_func_ref(ctx, f, insn->op2, proto, insn->type);
 	} else {
 		ir_emit_ref(ctx, f, insn->op2);
 	}
@@ -855,12 +930,11 @@ static void ir_emit_tailcall(ir_ctx *ctx, FILE *f, ir_insn *insn)
 		if (ctx->ir_base[insn->op2].op == IR_FUNC) {
 			fprintf(f, "%s", ir_get_str(ctx, ctx->ir_base[insn->op2].val.name));
 		} else {
-            IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
-			fprintf(f, "((");
-			ir_emit_func_ptr_cast(f, proto, insn->type);
-			ir_emit_ref(ctx, f, insn->op2);
-			fprintf(f, ")");
+			IR_ASSERT(ctx->ir_base[insn->op2].op == IR_FUNC_ADDR);
+			ir_emit_typed_func_ref(ctx, f, insn->op2, proto, insn->type);
 		}
+	} else if (ctx->ir_base[insn->op2].op == IR_PROTO) {
+		ir_emit_typed_func_ref(ctx, f, insn->op2, proto, insn->type);
 	} else {
 		ir_emit_ref(ctx, f, insn->op2);
 	}
@@ -955,33 +1029,6 @@ static void ir_emit_store(ir_ctx *ctx, FILE *f, ir_insn *insn)
 	fprintf(f, ";\n");
 }
 
-static void ir_emit_c_call_conv(FILE *f, uint32_t flags)
-{
-	switch (flags & IR_CALL_CONV_MASK) {
-		case IR_CC_FASTCALL:
-			fprintf(f, " __fastcall");
-			break;
-		case IR_CC_PRESERVE_NONE:
-			fprintf(f, " __attriute__((preserve_none))");
-			break;
-#if defined(IR_TARGET_X64)
-		case IR_CC_X86_64_SYSV:
-			fprintf(f, " __attriute__((sysv_abi))");
-			break;
-		case IR_CC_X86_64_MS:
-			fprintf(f, " __attriute__((ms_abi))");
-			break;
-#elif defined(IR_TARGET_AARCH64)
-		case IR_CC_AARCH64_SYSV:
-			break;
-		case IR_CC_AARCH64_DARWIN:
-			break;
-#endif
-		default:
-			IR_ASSERT((flags & IR_CALL_CONV_MASK) == IR_CC_DEFAULT || (flags & IR_CALL_CONV_MASK) == IR_CC_BUILTIN);
-	}
-}
-
 static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 {
 	ir_ref i, n, *p;
@@ -1001,9 +1048,12 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 	if (ctx->flags & IR_STATIC) {
 		fprintf(f, "static ");
 	}
-	ir_emit_c_call_conv(f, ctx->flags);
 	ir_emit_c_type_name(ctx->ret_type != (ir_type)-1 ? ctx->ret_type : IR_VOID, f);
-	fprintf(f, " %s(", name);
+	fprintf(f, " ");
+	if (ir_emit_c_call_conv(f, ctx->flags)) {
+		fprintf(f, " ");
+	}
+	fprintf(f, "%s(", name);
 	use_list = &ctx->use_lists[1];
 	n = use_list->count;
 	first = 1;
@@ -1260,8 +1310,15 @@ static int ir_emit_c_func(ir_ctx *ctx, const char *name, FILE *f)
 					}
 					break;
 				case IR_BITCAST:
-				case IR_PROTO:
 					ir_emit_bitcast(ctx, f, i, insn);
+					break;
+				case IR_PROTO:
+					ir_emit_def_ref(ctx, f, i);
+					fprintf(f, "(");
+					ir_emit_c_type_name(insn->type, f);
+					fprintf(f, ")");
+					ir_emit_typed_func_ref(ctx, f, insn->op1, (const ir_proto_t *)ir_get_str(ctx, insn->op2), insn->type);
+					fprintf(f, ";\n");
 					break;
 				case IR_INT2FP:
 				case IR_FP2INT:
@@ -1449,28 +1506,7 @@ void ir_emit_c_func_decl(const char *name, uint32_t flags, ir_type ret_type, uin
 	} else if (flags & IR_STATIC) {
 		fprintf(f, "static ");
 	}
-	ir_emit_c_type_name(ret_type, f);
-	fprintf(f, " ");
-	ir_emit_c_call_conv(f, flags);
-	fprintf(f, "%s(", name);
-	if (params_count) {
-		const uint8_t *p = param_types;
-
-		ir_emit_c_type_name(*p, f);
-		p++;
-		while (--params_count) {
-			fprintf(f, ", ");
-			ir_emit_c_type_name(*p, f);
-			p++;
-		}
-		if (flags & IR_VARARG_FUNC) {
-			fprintf(f, ", ...");
-		}
-	} else if (flags & IR_VARARG_FUNC) {
-		fprintf(f, "...");
-	} else {
-		fprintf(f, "void");
-	}
+	ir_emit_c_func_decl_ex(name, flags, ret_type, params_count, param_types, 0, f);
 	fprintf(f, ");\n");
 }
 

--- a/tests/c/call_addr_001.irt
+++ b/tests/c/call_addr_001.irt
@@ -1,0 +1,19 @@
+--TEST--
+001: constant function address call emits a casted function pointer
+--ARGS--
+--emit-c
+--CODE--
+{
+	int32_t c_1 = 7;
+	uintptr_t c_2 = func *0x1234(int32_t): int32_t;
+	l_1 = START(l_4);
+	int32_t d_3, l_3 = CALL/1(l_1, c_2, c_1);
+	l_4 = RETURN(l_3, d_3);
+}
+--EXPECT--
+int32_t test(void)
+{
+	int32_t d_1;
+	d_1 = ((int32_t (*)(int32_t))0x1234)(7);
+	return d_1;
+}

--- a/tests/c/call_addr_fastcall_001.irt
+++ b/tests/c/call_addr_fastcall_001.irt
@@ -1,0 +1,21 @@
+--TEST--
+001: constant function address call emits a typed function pointer with calling convention
+--TARGET--
+x86
+--ARGS--
+--emit-c
+--CODE--
+{
+	int32_t c_1 = 7;
+	uintptr_t c_2 = func *0x1234(int32_t): int32_t __fastcall;
+	l_1 = START(l_4);
+	int32_t d_3, l_3 = CALL/1(l_1, c_2, c_1);
+	l_4 = RETURN(l_3, d_3);
+}
+--EXPECT--
+int32_t test(void)
+{
+	int32_t d_1;
+	d_1 = ((int32_t (__fastcall *)(int32_t))0x1234)(7);
+	return d_1;
+}

--- a/tests/c/call_addr_preserve_none_x86_64_001.irt
+++ b/tests/c/call_addr_preserve_none_x86_64_001.irt
@@ -1,0 +1,21 @@
+--TEST--
+001: constant function address call emits a preserve-none function pointer on x86_64
+--TARGET--
+x86_64
+--ARGS--
+--emit-c
+--CODE--
+{
+	int32_t c_1 = 7;
+	uintptr_t c_2 = func *0x1234(int32_t): int32_t __preserve_none;
+	l_1 = START(l_4);
+	int32_t d_3, l_3 = CALL/1(l_1, c_2, c_1);
+	l_4 = RETURN(l_3, d_3);
+}
+--EXPECT--
+int32_t test(void)
+{
+	int32_t d_1;
+	d_1 = ((int32_t (__attribute__((preserve_none)) *)(int32_t))0x1234)(7);
+	return d_1;
+}

--- a/tests/c/call_addr_vararg_001.irt
+++ b/tests/c/call_addr_vararg_001.irt
@@ -1,0 +1,20 @@
+--TEST--
+001: constant function address vararg call emits a typed function pointer
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = "x=%d\n";
+	int32_t c_2 = 7;
+	uintptr_t c_3 = func *0x1234(uintptr_t, ...): int32_t;
+	l_1 = START(l_5);
+	int32_t d_4, l_4 = CALL/2(l_1, c_3, c_1, c_2);
+	l_5 = RETURN(l_4, d_4);
+}
+--EXPECT--
+int32_t test(void)
+{
+	int32_t d_1;
+	d_1 = ((int32_t (*)(uintptr_t, ...))0x1234)("x=%d\n", 7);
+	return d_1;
+}

--- a/tests/c/proto_call_fastcall_001.irt
+++ b/tests/c/proto_call_fastcall_001.irt
@@ -1,0 +1,24 @@
+--TEST--
+001: proto values keep typed function-pointer casts in C emission
+--TARGET--
+x86
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = 0x1234;
+	int32_t c_2 = 7;
+	l_1 = START(l_5);
+	uintptr_t d_3 = PROTO/2(c_1, func(int32_t): int32_t __fastcall);
+	int32_t d_4, l_4 = CALL/1(l_1, d_3, c_2);
+	l_5 = RETURN(l_4, d_4);
+}
+--EXPECT--
+int32_t test(void)
+{
+	uintptr_t d_1;
+	int32_t d_2;
+	d_1 = (uintptr_t)((int32_t (__fastcall *)(int32_t))0x1234);
+	d_2 = ((int32_t (__fastcall *)(int32_t))d_1)(7);
+	return d_2;
+}

--- a/tests/c/proto_call_preserve_none_aarch64_001.irt
+++ b/tests/c/proto_call_preserve_none_aarch64_001.irt
@@ -1,0 +1,24 @@
+--TEST--
+001: proto values keep preserve-none function-pointer casts on aarch64
+--TARGET--
+aarch64
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = 0x1234;
+	int32_t c_2 = 7;
+	l_1 = START(l_5);
+	uintptr_t d_3 = PROTO/2(c_1, func(int32_t): int32_t __preserve_none);
+	int32_t d_4, l_4 = CALL/1(l_1, d_3, c_2);
+	l_5 = RETURN(l_4, d_4);
+}
+--EXPECT--
+int32_t test(void)
+{
+	uintptr_t d_1;
+	int32_t d_2;
+	d_1 = (uintptr_t)((int32_t (__attribute__((preserve_none)) *)(int32_t))0x1234);
+	d_2 = ((int32_t (__attribute__((preserve_none)) *)(int32_t))d_1)(7);
+	return d_2;
+}

--- a/tests/c/proto_param_call_fastcall_001.irt
+++ b/tests/c/proto_param_call_fastcall_001.irt
@@ -1,0 +1,29 @@
+--TEST--
+001: parameter-backed proto call emits typed fastcall function-pointer casts
+--TARGET--
+x86
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = 0;
+	bool c_2 = 0;
+	bool c_3 = 1;
+	l_1 = START(l_6);
+	uintptr_t d_2 = PARAM(l_1, "p", 1);
+	int32_t d_3 = PARAM(l_1, "a", 2);
+	uintptr_t d_4 = PROTO(d_2, func(int32_t): int32_t __fastcall);
+	int32_t d_5, l_5 = CALL/1(l_1, d_4, d_3);
+	l_6 = RETURN(l_5, d_5);
+}
+--EXPECT--
+int32_t test(uintptr_t p, int32_t a)
+{
+	uintptr_t d_1 = p;
+	int32_t d_2 = a;
+	uintptr_t d_3;
+	int32_t d_4;
+	d_3 = (uintptr_t)((int32_t (__fastcall *)(int32_t))d_1);
+	d_4 = ((int32_t (__fastcall *)(int32_t))d_3)(d_2);
+	return d_4;
+}

--- a/tests/c/tailcall_addr_001.irt
+++ b/tests/c/tailcall_addr_001.irt
@@ -1,0 +1,16 @@
+--TEST--
+001: constant function address tailcall emits a typed function pointer
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = func *0x1234(void): int32_t;
+	l_1 = START(l_3);
+	int32_t d_2, l_2 = TAILCALL(l_1, c_1);
+	l_3 = UNREACHABLE(l_2);
+}
+--EXPECT--
+int32_t test(void)
+{
+	return ((int32_t (*)(void))0x1234)();
+}

--- a/tests/c/tailcall_addr_void_001.irt
+++ b/tests/c/tailcall_addr_void_001.irt
@@ -1,0 +1,17 @@
+--TEST--
+001: constant function address void tailcall emits a typed function pointer
+--ARGS--
+--emit-c
+--CODE--
+{
+	uintptr_t c_1 = func *0x1234(void): void;
+	l_1 = START(l_3);
+	l_2 = TAILCALL(l_1, c_1);
+	l_3 = UNREACHABLE(l_2);
+}
+--EXPECT--
+void test(void)
+{
+	((void (*)(void))0x1234)();
+	return;
+}


### PR DESCRIPTION
Fix C emission for calls through constant function addresses.

Previously, constant callees were assumed to be named IR_FUNC references. When the callee was a raw function address, the generated C did not cast the address to the function's actual prototype before calling it.

Emit constant function addresses as typed function pointers using the call prototype, including the return type, parameter types, and variadic arguments.