### PR TITLE
Fix compiler warnings in SCCP and x86 backend

### DIFF
--- a/ir_sccp.c
+++ b/ir_sccp.c
@@ -3653,7 +3653,7 @@ static ir_ref ir_iter_optimize_condition(ir_ctx *ctx, ir_ref control, ir_ref con
 			&& !IR_IS_SYM_CONST(ctx->ir_base[condition_insn->op2].op)) {
 		uint64_t c1, c2 = ctx->ir_base[condition_insn->op2].val.u64;
 		ir_insn *op1_insn = &ctx->ir_base[condition_insn->op1];
-		ir_val val;
+		ir_val val = {0};
 
 		if (op1_insn->op == IR_SHL
 		 && ctx->use_lists[condition_insn->op1].count == 1

--- a/ir_x86.dasc
+++ b/ir_x86.dasc
@@ -2914,14 +2914,14 @@ get_arg_hints:
 			if (IR_IS_TYPE_INT(IR_VECTOR_BASE_TYPE(type))) {
 				constraints->tmp_regs[n] = IR_SCRATCH_REG(IR_REG_RAX, IR_USE_SUB_REF, IR_DEF_SUB_REF);
 				n++;
-				if (insn->op == IR_MUL && insn->op == IR_DIV && insn->op == IR_MOD) {
+				if (insn->op == IR_MUL || insn->op == IR_DIV || insn->op == IR_MOD) {
 					constraints->tmp_regs[n] = IR_SCRATCH_REG(IR_REG_RDX, IR_USE_SUB_REF, IR_DEF_SUB_REF);
 					if (IR_IS_CONST_REF(insn->op2)) {
 						constraints->tmp_regs[n] = IR_SCRATCH_REG(IR_REG_RCX, IR_USE_SUB_REF, IR_DEF_SUB_REF);
 						n++;
 					}
 					n++;
-				} else if (insn->op == IR_SHL && insn->op == IR_SHR && insn->op == IR_SAR) {
+				} else if (insn->op == IR_SHL || insn->op == IR_SHR || insn->op == IR_SAR) {
 					constraints->tmp_regs[n] = IR_SCRATCH_REG(IR_REG_RCX, IR_USE_SUB_REF, IR_DEF_SUB_REF);
 					n++;
 				} else if (IR_IS_CONST_REF(insn->op2) && ir_type_size[IR_VECTOR_BASE_TYPE(type)] == 8) {

--- a/tests/x86_64/div_008.irt
+++ b/tests/x86_64/div_008.irt
@@ -1,0 +1,45 @@
+--TEST--
+008: vector DIV expand keeps scalar args live
+--TARGET--
+x86_64-*-sysv
+--ARGS--
+--run
+--CODE--
+extern func printf(uintptr_t, ...): int32_t;
+func test(<uint32_t*4>, <uint32_t*4>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t;
+func test(<uint32_t*4>, <uint32_t*4>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t
+{
+	uint32_t c_0 = 0;
+	l_1 = START(l_8);
+	<uint32_t*4> x = PARAM(l_1, "x", 1);
+	<uint32_t*4> y = PARAM(l_1, "y", 2);
+	uint32_t a = PARAM(l_1, "a", 3);
+	uint32_t b = PARAM(l_1, "b", 4);
+	uint32_t c = PARAM(l_1, "c", 5);
+	uint32_t d = PARAM(l_1, "d", 6);
+	<uint32_t*4> v = DIV(x, y);
+	uint32_t e = EXTRACT(v, c_0);
+	uint32_t ret = ADD(e, c);
+	l_8 = RETURN(l_1, ret);
+}
+func main(void): int32_t
+{
+	uint32_t c_1 = 1;
+	uint32_t c_2 = 2;
+	uint32_t c_3 = 3;
+	uint32_t c_4 = 4;
+	uint32_t c_7 = 7;
+	uint32_t c_100 = 100;
+	<uint32_t*4> vx = SPLAT(c_100);
+	<uint32_t*4> vy = SPLAT(c_7);
+	uintptr_t c_test = func test(<uint32_t*4>, <uint32_t*4>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t;
+	uintptr_t c_fmt = "%u\n";
+	uintptr_t c_printf = func printf(uintptr_t, ...): int32_t;
+	int32_t c_ret0 = 0;
+	l_1 = START(l_4);
+	int32_t r_1, l_2 = CALL/6(l_1, c_test, vx, vy, c_1, c_2, c_3, c_4);
+	int32_t r_2, l_3 = CALL/2(l_2, c_printf, c_fmt, r_1);
+	l_4 = RETURN(l_3, c_ret0);
+}
+--EXPECT--
+17

--- a/tests/x86_64/shr_002.irt
+++ b/tests/x86_64/shr_002.irt
@@ -1,0 +1,46 @@
+--TEST--
+002: vector SHR expand keeps scalar args live
+--TARGET--
+x86_64-*-sysv
+--ARGS--
+--run
+--CODE--
+extern func printf(uintptr_t, ...): int32_t;
+func test(<uint8_t*16>, <uint8_t*16>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t;
+func test(<uint8_t*16>, <uint8_t*16>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t
+{
+	uint32_t c_0 = 0;
+	l_1 = START(l_8);
+	<uint8_t*16> x = PARAM(l_1, "x", 1);
+	<uint8_t*16> y = PARAM(l_1, "y", 2);
+	uint32_t a = PARAM(l_1, "a", 3);
+	uint32_t b = PARAM(l_1, "b", 4);
+	uint32_t c = PARAM(l_1, "c", 5);
+	uint32_t d = PARAM(l_1, "d", 6);
+	<uint8_t*16> v = SHR(x, y);
+	uint8_t e = EXTRACT(v, c_0);
+	uint32_t z = ZEXT(e);
+	uint32_t ret = ADD(z, d);
+	l_8 = RETURN(l_1, ret);
+}
+func main(void): int32_t
+{
+	uint32_t c_1 = 1;
+	uint32_t c_2 = 2;
+	uint32_t c_3 = 3;
+	uint32_t c_4 = 4;
+	uint8_t c_3u8 = 3;
+	uint8_t c_128 = 128;
+	<uint8_t*16> vx = SPLAT(c_128);
+	<uint8_t*16> vy = SPLAT(c_3u8);
+	uintptr_t c_test = func test(<uint8_t*16>, <uint8_t*16>, uint32_t, uint32_t, uint32_t, uint32_t): uint32_t;
+	uintptr_t c_fmt = "%u\n";
+	uintptr_t c_printf = func printf(uintptr_t, ...): int32_t;
+	int32_t c_ret0 = 0;
+	l_1 = START(l_4);
+	int32_t r_1, l_2 = CALL/6(l_1, c_test, vx, vy, c_1, c_2, c_3, c_4);
+	int32_t r_2, l_3 = CALL/2(l_2, c_printf, c_fmt, r_1);
+	l_4 = RETURN(l_3, c_ret0);
+}
+--EXPECT--
+20


### PR DESCRIPTION
Fixes two compiler warnings + introduces two regression tests that exercises fixed paths. Previously those paths were uncovered.